### PR TITLE
Add blog section with imported legacy posts

### DIFF
--- a/content/blog/index.njk
+++ b/content/blog/index.njk
@@ -1,0 +1,46 @@
+---
+layout: base.njk
+title: Dave Hulbert - Blog
+---
+<main class="px-6 py-16 sm:px-10">
+  <div class="mx-auto flex max-w-4xl flex-col gap-12">
+    <header class="space-y-4">
+      <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-400">Archive</p>
+      <h1 class="text-4xl font-semibold tracking-tight text-slate-100">Writing and Essays</h1>
+      <p class="text-lg text-slate-300">
+        A collection of posts from my previous blog, spanning engineering, leadership, and experiments.
+      </p>
+    </header>
+    <div class="flex flex-col divide-y divide-slate-800/80 border border-slate-800/60 bg-slate-900/40">
+      {% for post in collections.blog | reverse %}
+      <article class="group flex flex-col gap-3 px-6 py-6 transition hover:bg-slate-900/70 sm:px-8">
+        <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400">
+          <time datetime="{{ post.date | isoDate }}">{{ post.date | readableDate }}</time>
+          {% if post.data.categories %}
+            {% set categoryList = post.data.categories %}
+            {% if categoryList is string %}
+              {% set categoryList = categoryList | split(' ') %}
+            {% endif %}
+            <ul class="flex flex-wrap gap-2">
+              {% for category in categoryList %}
+              <li class="rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1 text-xs uppercase tracking-wide text-slate-300">{{ category }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+        <h2 class="text-2xl font-semibold tracking-tight text-slate-100">
+          <a class="hover:text-sky-300" href="{{ post.url }}">{{ post.data.title }}</a>
+        </h2>
+        {% if post.templateContent %}
+        {% set summary = post.templateContent | striptags | truncate(220, true, '…') %}
+        <p class="text-base text-slate-300">{{ summary }}</p>
+        {% endif %}
+        <a class="mt-2 inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300" href="{{ post.url }}">
+          Read more
+          <span aria-hidden="true">→</span>
+        </a>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</main>

--- a/content/blog/posts/2012-05-14-jquery-fast-click.md
+++ b/content/blog/posts/2012-05-14-jquery-fast-click.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title:  "New jQuery plugin for mobile browsers: jQuery Fast Click"
+date:   2012-05-14 12:24:07
+categories: javascript mobile
+---
+
+Mobile browsers delay browser clicks (or, more accurately, taps) by 300ms so they can detect double taps. This can be great but if you want to speed up clicks in your mobile site or app, you can use my plugin: [jQuery Fast Click](http://dave1010.github.com/jquery-fast-click/).
+
+The [code is on GitHub](https://github.com/dave1010/jquery-fast-click) and it’s under a Creative Commons Attribution 3.0 License. It’s tested on Android and iOS but if you have any issues on jQuery Fast Click, please use [GitHub’s issues](https://github.com/dave1010/jquery-fast-click/issues).

--- a/content/blog/posts/2012-05-18-responsive-design.md
+++ b/content/blog/posts/2012-05-18-responsive-design.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title:  "Taking Responsive Design a few steps forwards"
+date:   2012-05-18 12:24:07
+categories: css web
+---
+
+Responsive design today is great: different layouts can be served to different screen sizes. In the future, extra media queries could be available to web developers and designers to allow the content of a page respond to a whole range of capabilities.
+
+Possibly the most useful is being able to serve different content based on network bandwidth and latency. If on a limited data plan, you could tell websites you don’t want want HD content by default. Mobile users with high bandwidth but a poor network latency may have content adjusted for them in a different way to someone connected via a low-latency, low-bandwidth ethernet link.
+
+This would allow device pixel media queries to be used just for screen sizes, without making assumptions that would end up showing a full site to someone tethering their laptop to a GPRS connection or a cut-down version to someone who happened to resize their browser.
+
+In addition to network conditions (and even preferences), a whole host of other capabilities could be determined via media queries. A hover menu could be limited to users with a mouse. Keyboard shortcuts could be shown to users with hardware keyboards. Complex animations could be disabled by default for users with lower-spec CPUs or GPUs.
+
+This finer grained view of the user would reduce the assumptions currently made by lots of websites and allow website authors to provide sensible defaults to users without having to assume context.
+
+In terms of getting these implemented, the next steps would probably be to have discussion on W3C/WHATWG mailing lists and file some bugs in browsers. Would anyone like to help take responsive design further?

--- a/content/blog/posts/2012-07-17-psr-0-1-2.md
+++ b/content/blog/posts/2012-07-17-psr-0-1-2.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title:  "PHP coding standards and style guides"
+date:   2012-07-17 19:54:07
+categories: php
+---
+
+
+
+The PHP Framework Interoperability Group (PHP-FIG) are a group representing most of the big names in the PHP world such as Zend and Symfony. The group has formed to encourage PHP frameworks to be more interoperable. They’ve come up with 3 standards: PSR-0, PSR-1 and PSR-2.
+
+## PSR-0: Autoloader
+
+PSR-0 is all about autoloading classes. It basically says that classes must in directories matching their namespace and file names must be the same case as class names. It also specifies legacy PEAR-style class names with `_` corresponding to a directory separator.
+
+If you don’t name classes this way yet, I’d encourage you to start now. This means you should be able to use any compatible autoloader to load components from different projects. E.g. you can use the Symfony2 framework’s autoloader to load Doctrine’s ORM component.
+
+## PSR-1: Basic Coding Standard
+
+PSR-1 defines sensible standards. They’re based on the average of the FIG projects. Just about all modern code you encounter is likely to already confirm to PSR-1. You’ll find things like using `<?php` instead of `<?` and making files UTF-8. The only thing some people may debate is method names being in camelCase.
+
+Even if you don’t ever share code with anyone else, following PSR-1 will make things easier for yourself.
+
+## PSR-2: Coding Style Guide
+
+This is where things get interesting. Many people don’t like PSR-2 (lots of them appear to be the same people supporting PHP 5.2 frameworks) but I think it’s a great step forward for the PHP community, even if it means I have to change my coding style a little.
+
+The first guideline is spaces not tabs. Having been in the “tab” camp for over a decade, I thought switching to spaces would be a pain. Fortunately [Sublime Text](http://www.sublimetext.com/) made the switch pretty seamless. I still prefer tabs to spaces but the more I work with other developers (both at work and Open Source projects), the more I value the consistency of only using spaces. This is incredibly important when working with diffs in source control.
+
+Next is a soft line limit of 120 characters and a recommendation of keeping to 80 characters. This encourages you to keep code clear and readable, as well as making editing files on remote servers and from mobile phones easier. PSR-2 doesn’t mention total number of lines in a file but I’d recommend a soft limit of 300 lines.
+
+Most of the other guides are about spaces and newlines around braces. As with everything else in the FIG guides these are based from a survey of the member projects. Getting into the habit of following PSR-2 may take some time but is worth the effort IMO.
+
+## PHP CS – Coding Standards Fixer
+
+Tweaking spaces and newlines in an existing project to conform to the PSRs isn’t fun. Luckily [Fabien Potencier](http://fabien.potencier.org/) (of Symfony fame) has created a the [Cosing Standards Fixer](http://cs.sensiolabs.org/) to make files comply with much of PSR-1 and PSR-2.
+
+## WordPress
+
+There are lots of projects that have their own coding standards and don’t have any plans on conforming to the FIG’s standards. [WordPress](http://codex.wordpress.org/WordPress_Coding_Standards) is one of the biggest of these and is also one of the projects I work with the most. I’ve created a [ticket to track implementing PSR-0](http://core.trac.wordpress.org/ticket/21300), which would be a great start for WordPress. If that goes down well then I’ll do the same for PSR-1 and PSR-2. If you use WordPress or would like to see it implement PSR-0, please get involved and comment on the bug.

--- a/content/blog/posts/2012-07-30-immediately-invoked-function-expressions.md
+++ b/content/blog/posts/2012-07-30-immediately-invoked-function-expressions.md
@@ -1,0 +1,86 @@
+---
+layout: post
+title:  "Immediately-Invoked Function Expressions in PHP"
+date:   2012-07-30 08:14:07
+categories: php javascript
+---
+
+
+### In JavaScript
+
+A common patten in JavaScript is [immediately-invoked function expressions](http://benalman.com/news/2010/11/immediately-invoked-function-expression/), also known as self-executing anonymous functions. These allow you to create a private scope that won’t pollute the global namespace. They look like this:
+
+```javascript
+<?php
+(function () {
+    // variables defined here are 
+    // only visible in this scope
+}());
+```
+
+
+### In PHP
+
+Since PHP 5.3 brought along anonymous functions, the same can be done in PHP. Albeit with a slightly less elegant syntax:
+
+```javascript
+<?php
+call_user_func(function() {
+    // do something
+});
+```
+
+
+
+This is useful in PHP if you have some code that has side effects but you don’t want to litter variables.
+Real world examples
+
+When bootstrapping a framework or CMS, you often have to setup the environment by defining some constants. With IIFEs you’re free to use variables liberally so you’re code’s easier to understand.
+
+```javascript
+<?php
+call_user_func(function() {
+    // do some work, creating $result
+    define('SOMETHING', $result)
+});
+```
+
+
+You can even return a variable from the function and assign it to a variable:
+
+```javascript
+<?php
+$var = call_user_func(function() {
+	$a = 2;
+	$b = 2;
+	return $a + $b;
+});
+```
+
+
+Another use is registering namespaces with autoloaders (if you’re not using composer yet):
+
+```javascript
+<?php
+call_user_func(function() {
+    require_once './vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
+    $loader = new Symfony\Component\ClassLoader\UniversalClassLoader();
+    $loader->registerNamespace('Acme', __DIR__.'/vendor/acme/src');
+});
+```
+
+
+### The future?
+
+PHP 5.5 looks like it has lots of [interesting features](http://nikic.github.com/2012/07/10/What-PHP-5-5-might-look-like.html). Hopefully one them will be better function dereferencing. If it is, we can expect to have a syntax like the following, without the ugly call to call_user_func:
+
+```javascript
+<?php
+// php 5.5?
+function() {
+    // do something
+}();
+```
+
+
+It’s great to see PHP improving and gradually making functions first-class citizens. Perhaps one day we’ll be able to pass functions around in PHP as easily as as we can in languages like JavaScript.

--- a/content/blog/posts/2012-08-22-imagemagick.md
+++ b/content/blog/posts/2012-08-22-imagemagick.md
@@ -1,0 +1,47 @@
+---
+layout: post
+title:  "Batch converting images with ImageMagick"
+date:   2012-08-22 21:24:07
+categories: bash shell linux
+---
+
+
+Every now and then I need to batch resize or change the quality in some images. Photoshop and the GIMP let you do this, which is fine if you’re happy using your mouse or lots of RAM. The most efficient way of processing images is with ImageMagick. ImageMagick is the canonical way to do image manipulation and many GUI tools are based on it. ImageMagick is a useful tool to know and learning the basics of it will hopefully save you lots of time.
+
+First up, you may need to install ImageMagick. A `sudo apt-get install imagemagick` for Ubuntu/Debian or a `yum install ImageMagick` for Fedora/CentOS should do the trick if you’re on Linux. Head to the [ImageMagick download page](http://www.imagemagick.org/script/binary-releases.php) if you’re using a different OS.
+
+ImageMagick’s main commands are `convert` (create a new file) and `mogrify` (overwrite a file). These commands take many options and can do lots of interesting stuff. Here’s a couple of snippets that should come in handy.
+
+## Reducing image quality / size
+
+If you need to reduce the file size of some jpgs (eg so their more suitable for the web), you can mogrify all images in the current directory like this:
+
+    # give all jpg images a quality of 70
+    mogrify -quality 70 *.jpg
+
+The 70 here is the quality, which can be anything from 0 to 100. Unfortunately increasing the quality of a low quality image has no effect, [unless you’re CSI](http://www.lolwtfcomics.com/upload/uploads/1317571091.jpg).
+
+*Note: ImageMagick supports multiple input files, so you can easily use them with your shell’s file expansion (e.g. * and ?). If you want more control, you can always use [find and xargs](http://www.linuxplanet.com/linuxplanet/tutorials/6522/1) or a simple [for loop](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-7.html).*
+
+To shrink large images (8MP images are common on today’s smartphones), use the `-resize` option instead of (or as well as) `-quality`:
+
+    # shrink to 1/4 original size
+    mogrify -resize 25% photo.jpg 
+    # resize to fit in a box 1024x768
+    mogrify -resize 1024x768 photo.jpg 
+    # resize to max width 800px, keeping aspect ratio, reducing quality to 60
+    mogrify -resize 800 -quality 60 photo.jpg
+
+## Convert between JPG / PNG / GIF
+
+Unlike `mogrify`, `convert` takes input and output file parameters. This means converting between different formats is as simple as choosing a different output format:
+
+    convert image.png image.jpg
+
+If you’re dealing with PNG images, [Pngcrush](http://pmt.sourceforge.net/pngcrush/) is useful too.
+
+## Further reading
+
+I’ve only touched on a small fragment of what ImageMagick is capable of. It also allows you to add filters like Instagram and layers like text and watermarks.
+
+If you thirst for more image processing knowledge, read through the documentation for [convert](http://www.imagemagick.org/www/convert.html) and [mogrify](http://www.imagemagick.org/www/mogrify.html) on the ImageMagick site, then have a look at some of the [other commands](http://www.imagemagick.org/www/command-line-tools.html) ImageMagick provides.

--- a/content/blog/posts/2012-11-27-generators.md
+++ b/content/blog/posts/2012-11-27-generators.md
@@ -1,0 +1,82 @@
+---
+layout: post
+title:  "Generators in PHP 5.5 (with PDO)"
+date:   2012-11-27 08:14:07
+categories: php
+---
+
+As the first alpha of PHP 5.5 has been released, now is a great time to play with its new features. The first new feature is [generators](https://wiki.php.net/rfc/generators). Generators are like very simple iterators.
+
+PDO’s PDOStatement class implements Traversable, which means you can iterate over it with foreach:
+
+```php
+<?php
+$sth = $dbh->prepare("SELECT * FROM users");
+$sth->execute();
+
+foreach ($sth as $result) {
+    print_r($result);
+}
+```
+
+
+This is great as it abstracts away much of retrieving result sets from a database and gets you straight to an array-like structure. This iterator is great as PDO only retrieves the results as they’re requested, reducing memory usage.
+
+You can recreate this by making a class that implements Iterator and its abstract methods. Whilst this is quite simple, PHP 5.5 brings generators, which allow you to create iterators using a single function.
+
+Here’s an example, using PDO again. First, some boiler plate code to set up:
+
+```php
+<?php
+$dbh = new PDO('sqlite::memory:'); 
+$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$dbh->exec("CREATE TABLE users (
+	id INTEGER NOT NULL,
+	name VARCHAR(255),
+	PRIMARY KEY (id)
+)");
+
+$dbh->exec("INSERT INTO users (id, name) VALUES (1, 'tom')");
+$dbh->exec("INSERT INTO users (id, name) VALUES (2, 'dick')");
+$dbh->exec("INSERT INTO users (id, name) VALUES (3, 'harry')");
+
+$sth = $dbh->prepare("SELECT * FROM users");
+$sth->execute();
+```
+
+
+If we wanted to, we could now iterate over $sth using foreach like so:
+
+```php
+<?php
+foreach ($sth as $result) {
+	print_r($result);
+}
+```
+
+
+Instead, lets create a generator that fetches rows from $sth, but passes control back to the foreach:
+
+```php
+<?php
+function fetch($sth, $fetchMode) {
+    while ($result = $sth->fetch($fetchMode)) {
+        yield $result;
+    }
+}
+```
+
+
+The key here is the “yield” keyword, which can be thought of as “start returning an item from an array”. The foreach can then loop through the results like this:
+
+```php
+<?php
+$results = fetch($sth, PDO::FETCH_OBJ);
+foreach ($results as $result) {
+	echo $result->name . "\n";
+}
+```
+
+
+Whilst this example is a bit pointless (as PDO already provides an Interator), you can see that generators are a simple way of creating iterators.
+

--- a/content/blog/posts/2013-01-03-bitcoin.md
+++ b/content/blog/posts/2013-01-03-bitcoin.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title:  "Bitcoin: the cryptographic currency"
+date:   2013-01-03 19:24:07
+categories: economics cryptography
+---
+
+Bitcoin is a digital currency without any central control. It was introduced 4 years ago today (3rd January 2009). 1 Bitcoin (BTC) is currently [worth around $13](http://bitcoincharts.com/). Last year Bitcoin grew considerably in market cap (now about $150 million) and popularity, with many organisations accepting Bitcoin as a form of payment.
+
+As a software developer interested in security, the idea of a distributed digital currency with foundations in cryptography is fascinating. Read on if you want to find out more about Bitcoin or just have 5 minutes to spare.
+
+## The problem of double-spending
+
+Most currencies (virtual and non) have a central authority that issues the currency and can verify transactions to stop double spending. Bitcoin is different in that it is decentralised. This means that there is a global peer-to-peer network of computers that verify transactions and issues currency.
+
+A big problem in virtual currencies is [double spending](http://en.wikipedia.org/wiki/Double-spending). If something is on a computer or a network then it can easily be copied (even if it is encrypted). If you give me a secret file, there is no guarantee that I won’t copy the file and distribute it to 10 other people. The same can occur with currencies: if I have 1 virtual dollar, I could send it to as many people as I wanted.
+
+Simply speaking, Bitcoin gets around the problem of double spending by logging every transaction and sharing it with everyone in a “block chain”. If Alice sends Bob 1 BTC then she will not be able to send that same Bitcoin to Carol: Carol knows that it has already been sent to Bob due to the log in the block chain.
+
+## Gold and Bitcoins
+
+There is no central issuer of Bitcoins as there is for USD or GBP. Instead, Bitcoins are digitally “mined”, similar to how gold is mined. Bitcoins are similar to gold in many ways:
+
+* They are both obtained (mined) by doing work (digging or solving mathematical equations).
+* There is a limited supply (there will only be 21 million BTC).
+* As the un-mined supply decreases, the mining effort increases and mining becomes less profitable.
+Over time people create more efficient machines to make mining more profitable. For example, Bitcoin miners use special hardware (FPGAs and now ASICs).
+* They can both be misplaced and lost forever.
+* Bitcoins and gold (or anything used as a currency) have a value because people are willing to exchange goods and services for them.
+
+## How mining works
+
+The principal behind mining Bitcoins is that it takes lots of work to do but not much work to verify. A simplified analogy is trying to find whole numbers under a trillion, with a square root that has the digits 12345 near the beginning (using a calculator). It would take you years to go through all trillion possible possibilities but you could verify a possible solution in seconds.
+
+The “work” that Bitcoin miners do is finding [SHA-256 hashes](http://en.wikipedia.org/wiki/SHA-2) (a hash designed by the NSA) that starts with multiple 0′s. People have invested considerable sums in mining “rigs” used to perform these hashes, which also serve to verify the block chain is valid.
+Conclusion
+
+As Bitcoin enters its 5th year of existence, I believe it will become increasingly more prevalent in the media and society. If you’re interested in cryptography or economics I’d recommend you [look into Bitcoin](https://en.bitcoin.it/wiki/How_bitcoin_works) some more and get an understanding of how it works.
+
+Please note: forex markets are risky and there’s lots of [misinformation about Bitcoin](http://bitcoinmagazine.net/common-misconceptions-about-bitcoin-guide/) so take care with your dabbling. I am not a financial advisor!

--- a/content/blog/posts/2013-01-27-conway.md
+++ b/content/blog/posts/2013-01-27-conway.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title:  "Conway’s Game of Life in Canvas"
+date:   2013-01-27 18:14:07
+categories: javascript
+---
+
+I haven’t done much with [Canvas](https://developer.mozilla.org/en-US/docs/HTML/Canvas/Tutorial), so I thought I’d experiment by making [Conway’s Game of Life](http://en.wikipedia.org/wiki/Conway_game) with a little JavaScript. Conway’s Game of Life is based on a grid of cells, which are either alive or dead. It has 4 simple rules rules:
+
+1. Any live cell with fewer than two live neighbours dies, as if caused by under-population.
+2. Any live cell with two or three live neighbours lives on to the next generation.
+3. Any live cell with more than three live neighbours dies, as if by overcrowding.
+4. Any dead cell with exactly three live neighbours becomes a live cell, as if by reproduction
+
+These simple rules allow anything to be created. For example:
+
+![Gliders](http://upload.wikimedia.org/wikipedia/commons/e/e5/Gospers_glider_gun.gif)
+
+Gliders in Conway’s Game of Life (from Wikipedia)
+
+
+You can see the code on [GitHub](https://github.com/dave1010/conway-canvas/blob/master/conway.js). It’s very basic but works OK and isn’t too bad for a couple of hours whilst watching TV (it may eat up your CPU a little, sorry). Pull requests, ideas and suggestions welcome.
+
+You can see it in action in the header of this blog. If you move your mouse over it then it will leave a trail of blocks. Clicking on the canvas will add lots of random cells.

--- a/content/blog/posts/2014-01-18-laravel-di.md
+++ b/content/blog/posts/2014-01-18-laravel-di.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Better Dependency Injection in Laravel"
+date:   2012-01-18 12:24:07
+categories: php laravel
+---
+
+We all love using Dependency Injection but often Laravel’s facades and IoC container are used more like a static service locator, which (despite being testable) can easily lead to violations of the [Dependency Inversion Principle](http://en.wikipedia.org/wiki/Dependency_inversion_principle) (the D in [SOLID](http://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29)).
+
+There’s been a lot of discussion around this in the PHP community recently, with calls to [stop using facades](http://programmingarehard.com/2014/01/11/stop-using-facades.html) as well as how [service locators can be used safely](http://dongilbert.net/a-case-for-service-location/) (the comments here are good too).
+
+The great news is Taylor, the main author of Laravel, has [responded to this](http://taylorotwell.com/response-dont-use-facades/) and [made a change](https://github.com/laravel/framework/commit/7e3a99ebbab959324eebd88bdc38667f3fd35461) to Laravel in v4.1.15 that makes it much easier to inject dependencies directly into controllers.
+
+I’m happy to see constructive criticism actually influencing and benefiting a framework so positively. Hopefully we’ll see more if this in the PHP community!

--- a/content/blog/posts/2014-02-01-strace.md
+++ b/content/blog/posts/2014-02-01-strace.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Strace"
+date:   2014-02-01 12:24:07
+categories: linux
+---
+
+Quick strace command that I use all the time to see what files a process is opening:
+
+    strace -f <command> 2>&1 | grep ^open
+
+Really useful to see what config files something is reading (and the order) or to see what PHP (or similar) files are being included.
+
+There’s normally other ways to do this (eg using a debugger) but sending strace’s stderr to stdout and piping through grep is useful in so many cases it’s become a command I use every day or 2.

--- a/content/blog/posts/2014-10-30-designing-through-mocking.md
+++ b/content/blog/posts/2014-10-30-designing-through-mocking.md
@@ -1,0 +1,112 @@
+---
+layout: post
+title:  "Notes on designing through mocking"
+date:   2014-10-30 21:44:07
+categories: design php
+---
+
+My notes on Everzet's talk "Design how your objects talk through mocking" at PHPNW14
+
+* Everzet's [Original slide deck](http://www.slideshare.net/everzet/design-how-your-objects-talk-through-mocking)
+* Code sample here are using [Prophecy](https://github.com/phpspec/prophecy) to create test doubles
+
+# Different test doubles: Mocks, stubs, spies, dummies and fakes
+
+## Dummy
+
+* Don't care about. Passed around for typehinting.
+* No behaviour
+
+```php
+<?php
+class Foo { public function __construct(Dummy $dummy) {} }
+new Foo((new \Prophecy\Prophet)->prophesize(Dumnmy::class)->reveal());
+```
+
+
+## Stub
+
+* Has (basic) behaviour but no expectations (i.e. injects input into SUT but never handles output)
+* Dummy that you call a method on
+* Promises it will always return the same thing (`willReturn()`)
+* Doesn't have to be called
+
+```php
+<?php
+function baz(Stub $stub) { return $stub->foo(123) === 'bar';}
+$stub = (new \Prophecy\Prophet)->prophesize(Stub::class);
+$stub->foo(123)->wilLReturn('bar');
+baz($stub->reveal());
+```
+
+
+## Mock
+
+* Define predictions (`shouldBeCalled()`), not promises
+* Verifies input from SUT
+
+```php
+<?php
+function foo(Mock $mock) { $mock->bar(123); }
+$prophet = new \Prophecy\Prophet;
+$mock = $prophet->prophesize(Mock::class);
+$mock->bar(123)->shouldBeCalled();
+foo($mock->reveal());
+$prophet->checkPredictions();
+```
+
+
+## Spy
+
+* Records behaviour
+* Assertions happen aftwerwards (`shouldHaveBeenCalled()`)
+
+```php
+<?php
+function foo(Spy $spy) { $spy->bar(123); }
+$spy = (new \Prophecy\Prophet)->prophesize(Spy::class);
+foo($spy->reveal());
+$spy->bar(123)->shouldHaveBeenCalled();
+```
+
+
+## Fake
+
+* Return data depending on input
+* Used to simplify a dependency. E.g. web service, DB, repository
+* Used to isolate SUT
+
+```php
+<?php
+interface WebServiceInterface { public function strtoupper($data); }
+class RealWebService implements WebServiceInterface {
+    public function strtoupper($data) { return file_get_contents('api.com/strtoupper/'.$data); }
+}
+class FakeWebService implements WebServiceInterface {
+    public function strtoupper($data) { return strtoupper($data); }
+}
+```
+
+
+# How mocking helps you follow SOLID principles
+
+* lots of mocks means *SRP* violation. Don't fake parts of objects: decouple them
+* Duplication in tests means *OCP* violation
+* Refused bequest: when you call a method that you didn't expect and there's an interface that covers the method. Means drivers are incompatible.
+* *LSP*: if objects implement the same interface then they should have the same behaviour. To fix, make a new interface and an adaptor
+* *ISP* violation. Don't force objects to have methods that aren't in a test. If a test doesn't use a whole interface then split the interface
+* *DIP*. Don't mock things you don't own. Don't test code you don't own, that's an integration test.
+
+# Testing outcomes vs testing communication between objects
+
+* Exposing outcomes vs exposing communications. Both. Tests usually expose outcomes but communication is important too.
+* Exposing outcomes forces you to create meaningless getters just for tests
+* Test outcomes when just 1 object. Test communication when multiple.
+* Exposing communication creates more objects
+* Don't use mocks for isolation, that's not what they're for (that's fakes)
+* Messaging is more important than state
+
+## Summary
+
+* TDD based on communication fixes SOLID violations before they happen
+

--- a/content/blog/posts/2014-11-04-should-i-use-globals.md
+++ b/content/blog/posts/2014-11-04-should-i-use-globals.md
@@ -1,0 +1,74 @@
+---
+layout: post
+title:  "Should I use global variables?"
+date:   2014-11-04 22:44:07
+categories: design php solid
+---
+
+Someone [posted a question](http://www.reddit.com/r/PHP/comments/2lct7y/question_do_you_use_globals_or_not/) about using global variables on [r/php](http://www.reddit.com/r/PHP), which I answered. Copied here for posterity.
+
+Using global state is technical debt. This means you're trading off short term wins (mostly writing less boiler plate code) with long term losses. If you get good at writing clean, SOLID code then any short term win from a shortcut is pretty much removed. There are lots of things that influence whether taking on technical debt is a good idea or not (including non-technical reasons), so the only correct answer is "it depends". 
+
+In my experience: **taking on this form of technical debt is virtually never worth it**.
+
+With a global variable you're doing something like this:
+
+```php
+<?php
+class Foo {
+    public function __construct()
+    {
+        $this->db = $GLOBALS['db'];
+    }
+}
+$foo = new Foo;
+```
+
+
+In this case, `$foo` has a hidden dependency on `$GLOBALS['db']`. That means from the outside, Foo is much harder to use, test, refactor and extend. Without refactoring, your code will rot whenever you add new features.
+
+Injecting your dependencies into `Foo` gives you the ability to decouple `Foo` from its dependencies. This makes testing and refactoring much easier. This can be done in 1 of 2 ways. Injecting a service locator is the first way to decoupling `Foo`.
+
+```php
+<?php
+class Foo {
+    public function __construct(ServiceLocator $serviceLocator)
+    {
+        $this->db = $serviceLocator->getDb();
+    }
+}
+new Foo($serviceLocator);
+```
+
+
+A service locator gives you separation between `Foo`'s dependency on the DB abstraction and the actual DB implementation. The service locator still keeps the dependency hidden inside `Foo` though, which means `Foo` is still quite hard to refactor. In fact, if your `$serviceLocator` itself is in the global scope, it's almost the same as injecting `$GLOBALS` into `Foo` (which isn't great):
+
+```php
+<?php
+class Foo {
+    public function __construct(array &$globals)
+    {
+        $this->db = $globals['db'];
+    }
+}
+new Foo($GLOBALS);
+```
+
+
+The best thing to do is to inject the actual dependencies into `Foo`. This means you can follow the [Dependency Inversion Principle](http://en.wikipedia.org/wiki/Dependency_inversion_principle) (the D in [SOLID](http://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29)).
+
+```php
+<?php
+class Foo {
+    public function __construct(Connection $db)
+    {
+        $this->db = $db;
+    }
+}
+new Foo($db);
+```
+
+
+If by doing this you're thinking "hey, that means I have to inject $db into hundreds of places" then your code is already relying on dependencies all over the places. This means you should (to speed up development and improve quality in the long term) refactor classes that depend on the dependencies to define clear responsibilities (the [S in SOLID](http://en.wikipedia.org/wiki/Single_responsibility_principle)).
+
+Note: as with all cases with technical debt vs clean code, there is a trade off. In general, your future self will thank you for doing it correctly early on.

--- a/content/blog/posts/2014-12-15-shared-resources-vs-singletons.md
+++ b/content/blog/posts/2014-12-15-shared-resources-vs-singletons.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title:  "Singletons: bad. Shared resources in a DIC: good."
+date:   2014-12-15 07:44:07
+categories: design php solid
+---
+
+## Singletons
+
+The Singleton pattern is when you can only instantiate 1 instance of a class. Realistically the only way to do this in PHP is by controlling object lifetime inside the object itself globally. This is bad as it uses global state (and is why Singleton is often considered an anti pattern).
+
+```php
+<?php
+trait Singleton {
+    public static function getInstance()
+    {
+        static $instance = null;
+        if (null === $instance) {
+            $instance = new static();
+        }
+  
+        return $instance;
+    }
+}
+```
+
+
+## Shared resources and services
+
+Another object (eg a DI container) can decide to only return a single instance of a class if it wants to. It does this by creating it the first time (usually lazily, the first time it is created, rather than ASAP) then sharing that resource by storing it as state in the container.
+
+```php
+<?php
+class Container {
+    private $instances = [];
+    private $factories = [];
+    
+    public function share($name, Callable $factory)
+    {
+        $this->factories[$name] = $factory
+    }
+
+    public function get($name)
+    {
+        if (!isset($this->instances[$name])) {
+            $factory = $this->factories[$name];
+            $this->instances[$name] = $factory;
+        }
+
+        return $this->instances[$name];
+    }
+}
+```
+
+
+## The similarities
+
+Both patterns reduce the amount of instance creation. This reduces memory usage and time cost. This is especially useful when dealing with external resources (such as file and databases).
+
+## The difference
+
+Often people confuse the Singleton pattern with a container sharing a resource. You can pretty much guarantee that using a Singleton is a bad idea. Sharing resources, however, is often a good idea.
+
+The difference between the Singleton pattern and a shared resource in a DIC is that the Singleton's state is global but the DIC's shared resource is stored in the DIC. The latter is not considered an anti pattern as the DIC is just like any object you can instantiate or mock.

--- a/content/blog/posts/2014-12-15-trait-tip.md
+++ b/content/blog/posts/2014-12-15-trait-tip.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title:  "Traits with interfaces"
+date:   2014-12-15 21:14:07
+categories: design php
+---
+
+In PHP, Traits can't implement interfaces. They can, however, include abstract methods. These methods then need to be implemented by the concrete class that implements the trait. This allows a trait to provide some boilerplate implementation that depends on an concrete implementation. This isn't always a good idea (it's verging on violating the [Dependency Inversion Principle](http://en.wikipedia.org/wiki/Dependency_inversion_principle) but it's better than a trait attempting to use a method that has no contract.
+
+Example:
+
+```php
+<?php
+trait LoggerTrait
+{
+    abstract public function log($level, $message, array $context = array());
+    
+    public function error($message, array $context = array())
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    } 
+}
+```
+

--- a/content/blog/posts/2015-01-12-psr-7.md
+++ b/content/blog/posts/2015-01-12-psr-7.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title:  "Thoughts on PSR-7"
+date:   2014-12-15 21:14:07
+categories: design php
+---
+
+PSR-7 contains interfaces for HTTP messages. These are like Symfony Kernel's Request and Response interfaces. Having these new interfaces would be great for the PHP community but there's a couple of issues with their current state that I'm not happy with.
+
+One of PSR-7's goals is "Keep the interfaces as minimal as possible". I think the current interfaces are not minimal enough.
+
+## Immutability
+
+Immutability is awesome. It mitigates a whole range of bugs like temporal coupling and can provide thread safety (yes, PHP has threads). Immutability means when an object is created then you can't modify it. This often reflects real world semantics. For example, you can find out what breed a dog is but you can't set the breed of a dog (unless you can modify its DNA).
+
+The original PHP DateTime object was mutable but we now have DateTimeImmutable too. Using DateTimeImmutable instead of DateTime makes it much easier to avoid bugs. You need to learn how DateTimeImmutable works differently to DateTime but once you have then the immutability makes code simpler and isn't difficult to use.
+
+Many of the HTTP messages in PSR-7 have forced mutability. Having mutability as part of the interfaces means every implementation needs to support mutability, otherwise they will start breaking the Liskov Substitution Principle.
+
+Arguments for mutability are that it makes code easier to write. Easy does not mean simple. Developers can learn how to do something that is relatively difficult but an interface that leads to complex design cannot be simplified without. Any difficulty can also be encapsulated at different levels, for example, a request builder.
+
+Mutability also pushes developers towards inheritance to add layers of behaviour. This means you get a long depth-of-inheritance, which is inflexible (eg diamond problem) and very hard to maintain. Immutability pushes developers towards composition (eg via decorators), which is much more flexible and easier to test.
+
+Note: HTTP implementations in projects like ruby and node are mutable. These are obviously successful but that doesn't mean they're correct. Mutability is definitely an option but I think immutability is better. 
+
+The argument for mutable objects so they can be iteratively build is moot. A mutable RequestBuilder can be used to create an immutable request. Request implementations could even provide mutability as an extra layer if they wanted. 
+
+## Being too strict to the spec
+
+I wasn't sure about this but I think it's worth mentioning. It's not something that's wrong per se, but could lead to issues. PSR-7 follows the spec very well. It also assumes that all other clients and servers will follow the spec perfectly. 
+
+The HTTP spec says that
+
+    Cache-Control: no-cache
+    Cache-Control: private
+
+is the same as
+
+    Cache-Control: no-cache, private
+
+If a request comes in like the former, then should it be transformed into the latter by PHP when proxying the request? What about requests with different case header names? The HTTP spec is explicit in these cases and it makes sense in 99% of cases for PSR-7 to follow this. 
+
+## Splitting client and server message interfaces
+
+As it currently stands, IncomingRequestInterface and OutgoingRequestInterface are separate interfaces, yet they both represent an HTTP request and have the same API. This seems to be due to mutability, so if the request was immutable then perhaps they could be combined.
+
+## Writing and reading from StreamableInterface
+
+This partly comes down to immutability but is also to do with the Interface Segregation Principle.
+
+A stream can be writable and/or readable. You can't ask for an interface you can read, nor can you ask for an interface you can write to. In effect, the stream's API can vary. You can call write() on a read-only stream and it will return false. Having a ReadableStreamInterface and a WritableStreamInterface would allow more flexibility and simpler code. Streams can always implement both interfaces. 

--- a/content/blog/posts/2015-02-04-psr-7-update.md
+++ b/content/blog/posts/2015-02-04-psr-7-update.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title:  "HTTP messaging PSR-7 update"
+date:   2015-02-04 08:14:07
+categories: design php frameworks
+---
+
+This is a quick update to my [original blog post criticizing mutability in PSR-7](http://createopen.com/design/php/2014/12/15/psr-7.html).
+
+The original blog post got a fair few tweets and traction on Reddit. More importantly, [Matthew Weier O'Phinney](https://twitter.com/mwop), the lead author of PSR-7, read it and took time to [respond](http://createopen.com/design/php/2014/12/15/psr-7.html#comment-1788691985) with valid feedback on mutability vs immutability.
+
+Before I got the chance to respond to Matthew, he [posted](https://groups.google.com/forum/#!msg/php-fig/9gK8vX8iYZ8/5PZ9rx8UvXYJ) on the PHP-FIG mailing list mentioning that he'd tried implementing an immutable version of the PSR in [phly/http](https://github.com/weierophinney/http/tree/feature/immutability) and it worked really well! 
+
+Immutability is (almost) always the best way to design interfaces. I'm please I (and others like [@everzet](https://twitter.com/everzet) on Twitter) managed to nudge the PSR in that direction.
+
+The current version of the [draft PSR-7 spec](https://github.com/php-fig/fig-standards/blob/master/proposed/http-message.md) is now immutable at it looks like the final version will be too.
+
+Finally, huge thanks to Matthew for not only responding to my feedback but also giving immutability a shot and even defending it on the PHP-FIG mailing list!

--- a/content/blog/posts/2015-02-05-balancing-technical-debt.md
+++ b/content/blog/posts/2015-02-05-balancing-technical-debt.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title:  "Balancing Technical Debt and Clean Code talk at the BCS"
+date:   2015-02-05 07:14:07
+categories: talk technical-debt
+---
+
+Last week I gave a [talk at BCS Dorset](http://www.dorset.bcs.org/events/base-balancing-technical-debt) about technical debt:
+
+> Balancing technical debt and getting things done is one of the hardest problems we have. When should we write beautiful, elegant, clean code and when should we just hammer away blindly at the keyboard until it's done? This talk goes in to why this balance is so difficult and covers everything from estimations to refactoring and testing, with a focus on real world web apps.
+
+This talk was at the BCS (The British Computing Society), so was a bit different from talking at developer user groups (where I've spoken before). It's always interesting giving more subjective talks based more on experience learned than more technical talks that are either right or wrong. The best bit was the Q&A, where there was lots of discussion with other people's experience of technical debt and architecture in startups, digital agencies and enterprises.
+
+I've included the slides below but most of them are visual cues rather than bullet points of information.
+
+<iframe src="//www.slideshare.net/slideshow/embed_code/44010632" width="425" height="355" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/dave1010uk/balancing-technical-debt-and-clean-code" title="Balancing Technical Debt and Clean Code" target="_blank">Balancing Technical Debt and Clean Code</a> </strong></div>

--- a/content/blog/posts/2015-04-28-tdd-notes.md
+++ b/content/blog/posts/2015-04-28-tdd-notes.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title:  "Test Driven Development training course notes"
+date:   2015-04-28 20:15:54
+categories: tdd design
+---
+
+A couple of weeks ago [Chris](https://twitter.com/tweetingsherry) and I went on a TDD course from [Codemanship](http://www.codemanship.co.uk/tdd.html).
+
+This post is an expansion of some of my notes from the course. As always, suggestions and corrects are welcome (especially as [pull requests](https://github.com/dave1010/dave1010.github.io)).
+
+## Schools of TDD
+
+There are 2 main schools of TDD: Classic style and London style.
+
+Testing is either about collaborations (mock objects), or tests about outcomes (assertions & stubs) - not both. Details of an interaction between collaborators often implies the outcome, so you need to be careful about mixing these.
+
+### Classic style
+
+Classic style is also known as Chicago or Detroit style and is described best by Beck's "Test-Driven Development". This focuses on algorithms and triangulation.
+
+First you start with the simplest test case, then gradually generalize the algorithm by adding more tests. This leads to Classic style being great for evolving algorithms. As the code is refactored, new objects are created.
+
+### London style
+
+London style is also known as Mockist style. It's best described by Freeman & Pryce's "Growing Object Oriented Software Guided By Tests" book (the GOOS book). This focuses on how objects talk to each other.
+
+London style is great for evolving complex systems - as this leads to a design where objects pass messages to each other.
+
+## The TDD cycle
+
+### Writing tests (red)
+
+Keep tests as close as possible to the code they're testing. Keep them in the same package and in the same namespace. Commits that change the behaviour of an object should also contain commits that update the tests. Organise tests to reflect organisation of model code.
+
+Test and model code should be in separate classes but test double classes belong with test code.
+
+Choose test names carefully: they should be self explanatory. Keep tests small. The larger the test is, the more work is required to make it pass. If more work is required to pass a test then the system is in the "red" state for longer.
+
+Start with an assertion, as this is the most important thing, then work backwards to get the object behaviour. Tests should only be asking 1 question, so they have only 1 reason to fail.
+
+When a test fails then it should be obvious what goes wrong. This means the process shouldn't die or fail to late. The test failure message should point to the exact place where code would need changing to fix it. You should _always_ confirm that the test fails meaningfully first.
+
+Isolate tests so they run independently. One failing test should not break any other test. Tests should be able to be ran in individual processes if required.
+
+
+
+
+### Passing tests (green)
+
+Code should become more generalized gradually, as it is passing more tests. Don't generalize on a solution too early.
+
+Practice TDD "as if you mean it". This means you cannot add more than the simplest code required to pass a test - even if a more generalized solution is obvious.
+
+
+### Refactoring
+
+TDD is unsustainable without refactoring. Refactoring must be done continually during the process. Refactoring is unsafe without (passing) tests. Don't be tempted to refactor if there are any failing tests.
+
+Duplicate code is a _clue_ to an opportunity for abstraction.
+
+Maintain your tests - keep them green. Test code should be refactored too, though they should be more DAMP (Descriptive And Meaningful Phrases) than DRY (Don't repeat yourself).
+
+Refactoring is mostly about redistributing responsibilities. It is critical for the right object to be responsible for the right behaviour. Once the responsibilities are in the right place, code and behaviour is much easier to test and change.
+
+
+## Testing
+
+You've finished development of a specific object when there are no more failing tests possible. Once you get to this point it is no longer TDD as it is not driving development. This activity is called "testing" and can be a legitimate thing to do!
+
+
+
+## Test doubles
+
+
+For an intro to test doubles, have a look at [my notes](http://createopen.com/design/php/2014/10/30/designing-through-mocking.html) on Konstantin Kudryashov's talk "Design how your objects talk through mocking".
+
+Don't mix up mocks and stubs. Using both at the same time leads to complexity and tests that are hard to maintain.
+
+
+
+### Stubs
+
+Stubs are for testing data and are used to provide the system under test with the right input.
+
+For example to test an import script, a CSV file stub may always return preset data when its data is queried.
+
+
+### Mocks (or spies)
+
+Mocks are for testing interactions between objects. They record interactions between objects and verify methods are called as expected.
+
+For example, an import script should call the method `persist()` on a mock repository, passing in an entity.
+
+Mocks shouldn't be overused as it means the implementation will be tied to the test. Mocks for static methods should be avoided. Mocks also shouldn't be used to make legacy code easier to test: the more you do it, the more it will bake in bad design.
+
+
+## Good Object Oriented design
+
+A good object oriented design passes the tests in the simplest way possible. The right objects are doing the right work and objects collaborate where they need to.
+
+You can help model OO design by using a Class Responsibility Collaborator (CRC) model. This is creating a set of index cards with the class name and 2 columns:
+
+* its responsibilities: what it does (behavior) and what it knows
+* its collaborators: other classes that it interacts with to fulfill its responsibilities
+
+When thge CRC model is complete, you can start writing tests for the object that isn't told what to do by anything else.
+
+Objects should only perform actions with what they explicitly know about. Objects shouldn't have to ask for data from other objects. This is basically the [Law of Demeter](http://en.wikipedia.org/wiki/Law_of_Demeter). This means objects should not leak data when not needed. This helps an interface stay narrow.
+

--- a/content/blog/posts/posts.11tydata.js
+++ b/content/blog/posts/posts.11tydata.js
@@ -1,0 +1,12 @@
+export default {
+  layout: "post.njk",
+  tags: ["blog"],
+  eleventyComputed: {
+    permalink: (data) => {
+      const slug = (data.page.fileSlug || "")
+        .replace(/^\d{4}-\d{2}-\d{2}-/, "")
+        .replace(/\/+$/, "");
+      return `/blog/${slug || data.page.fileSlug}/`;
+    }
+  }
+};

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,12 +1,40 @@
 export default function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ public: "." });
 
+  eleventyConfig.addFilter("readableDate", (dateObj, locale = "en-GB", options = { month: "long", day: "numeric", year: "numeric" }) => {
+    if (!(dateObj instanceof Date)) {
+      dateObj = new Date(dateObj);
+    }
+    return new Intl.DateTimeFormat(locale, options).format(dateObj);
+  });
+
+  eleventyConfig.addFilter("isoDate", (dateObj) => {
+    if (!(dateObj instanceof Date)) {
+      dateObj = new Date(dateObj);
+    }
+    return dateObj.toISOString().split("T")[0];
+  });
+
+  eleventyConfig.addFilter("split", (value, delimiter = " ") => {
+    if (!value && value !== "") {
+      return [];
+    }
+    if (Array.isArray(value)) {
+      return value;
+    }
+    return String(value)
+      .split(delimiter)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  });
+
   return {
     dir: {
       input: "content",
       layouts: "../src/layouts"
     },
     htmlTemplateEngine: "njk",
-    markdownTemplateEngine: "njk"
+    markdownTemplateEngine: "njk",
+    templateFormats: ["njk", "md", "markdown"]
   };
 }

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -1,0 +1,28 @@
+---
+layout: base.njk
+---
+<main class="px-6 py-16 sm:px-10">
+  <article class="blog-post mx-auto flex max-w-3xl flex-col gap-12">
+    <header class="space-y-4">
+      <a class="text-sm font-medium uppercase tracking-wide text-slate-400 hover:text-slate-200" href="/blog/">Blog</a>
+      <h1 class="text-4xl font-semibold tracking-tight text-slate-100">{{ title }}</h1>
+      <p class="text-base text-slate-400">
+        <time datetime="{{ page.date | isoDate }}">{{ page.date | readableDate }}</time>
+      </p>
+      {% if categories %}
+      {% set categoryList = categories %}
+      {% if categoryList is string %}
+        {% set categoryList = categoryList | split(' ') %}
+      {% endif %}
+      <ul class="flex flex-wrap gap-2 text-sm text-slate-300">
+        {% for category in categoryList %}
+        <li class="rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1">{{ category }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </header>
+    <div class="blog-post__content space-y-6 text-lg leading-relaxed text-slate-200">
+      {{ content | safe }}
+    </div>
+  </article>
+</main>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -7,3 +7,42 @@
     @apply selection:bg-sky-500/30 selection:text-slate-100;
   }
 }
+
+@layer base {
+  .blog-post__content h2 {
+    @apply text-3xl font-semibold text-slate-100;
+  }
+  .blog-post__content h3 {
+    @apply text-2xl font-semibold text-slate-100;
+  }
+  .blog-post__content h4 {
+    @apply text-xl font-semibold text-slate-100;
+  }
+  .blog-post__content p {
+    @apply text-lg leading-relaxed text-slate-200;
+  }
+  .blog-post__content a {
+    @apply text-sky-400 underline decoration-sky-500/40 underline-offset-4 hover:text-sky-300;
+  }
+  .blog-post__content ul {
+    @apply list-disc space-y-2 pl-5;
+  }
+  .blog-post__content ol {
+    @apply list-decimal space-y-2 pl-5;
+  }
+  .blog-post__content li {
+    @apply text-lg leading-relaxed text-slate-200;
+  }
+  .blog-post__content blockquote {
+    @apply border-l-4 border-sky-500/40 bg-slate-900/50 p-4 italic text-slate-200;
+  }
+  .blog-post__content pre {
+    @apply overflow-x-auto rounded-xl bg-slate-900/70 p-4 text-sm text-slate-100;
+  }
+  .blog-post__content code {
+    @apply rounded bg-slate-900/70 px-1 py-0.5 text-sm text-sky-200;
+  }
+  .blog-post__content img {
+    @apply mx-auto rounded-xl shadow-xl;
+  }
+}


### PR DESCRIPTION
## Summary
- import markdown posts from the legacy blog into `content/blog/posts`
- add a dedicated blog layout and index page styled for the new section
- extend Eleventy configuration and Tailwind styles to support post metadata and formatting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900babc1d5c832b91a149437bc3d1a1