### PR TITLE
Add navigation between home and blog pages

### DIFF
--- a/content/blog/index.njk
+++ b/content/blog/index.njk
@@ -5,6 +5,13 @@ title: Dave Hulbert - Blog
 <main class="px-6 py-16 sm:px-10">
   <div class="mx-auto flex max-w-4xl flex-col gap-12">
     <header class="space-y-4">
+      <a
+        class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
+        href="/"
+      >
+        <span aria-hidden="true">←</span>
+        Back to home
+      </a>
       <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-400">Archive</p>
       <h1 class="text-4xl font-semibold tracking-tight text-slate-100">Writing and Essays</h1>
       <p class="text-lg text-slate-300">

--- a/content/index.njk
+++ b/content/index.njk
@@ -32,6 +32,15 @@ title: Dave Hulbert - Engineer
           Whether you're exploring responsible AI adoption, scaling engineering organisations, or simply
           looking for pragmatic advice, I'd love to connect.
         </p>
+        <div>
+          <a
+            class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
+            href="/blog/"
+          >
+            Visit the blog
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add a call-to-action on the homepage that links to the blog
- add a link on the blog index page to navigate back to the homepage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900c5a488d0832bac79e5eaa887f240