### PR TITLE
Enable Eleventy syntax highlighting and fix blog code fences

### DIFF
--- a/content/blog/posts/imagemagick.md
+++ b/content/blog/posts/imagemagick.md
@@ -18,8 +18,10 @@ ImageMagick’s main commands are `convert` (create a new file) and `mogrify` (o
 
 If you need to reduce the file size of some jpgs (eg so their more suitable for the web), you can mogrify all images in the current directory like this:
 
-    # give all jpg images a quality of 70
-    mogrify -quality 70 *.jpg
+```bash
+# give all jpg images a quality of 70
+mogrify -quality 70 *.jpg
+```
 
 The 70 here is the quality, which can be anything from 0 to 100. Unfortunately increasing the quality of a low quality image has no effect, [unless you’re CSI](http://www.lolwtfcomics.com/upload/uploads/1317571091.jpg).
 
@@ -27,18 +29,22 @@ The 70 here is the quality, which can be anything from 0 to 100. Unfortunately i
 
 To shrink large images (8MP images are common on today’s smartphones), use the `-resize` option instead of (or as well as) `-quality`:
 
-    # shrink to 1/4 original size
-    mogrify -resize 25% photo.jpg 
-    # resize to fit in a box 1024x768
-    mogrify -resize 1024x768 photo.jpg 
-    # resize to max width 800px, keeping aspect ratio, reducing quality to 60
-    mogrify -resize 800 -quality 60 photo.jpg
+```bash
+# shrink to 1/4 original size
+mogrify -resize 25% photo.jpg
+# resize to fit in a box 1024x768
+mogrify -resize 1024x768 photo.jpg
+# resize to max width 800px, keeping aspect ratio, reducing quality to 60
+mogrify -resize 800 -quality 60 photo.jpg
+```
 
 ## Convert between JPG / PNG / GIF
 
 Unlike `mogrify`, `convert` takes input and output file parameters. This means converting between different formats is as simple as choosing a different output format:
 
-    convert image.png image.jpg
+```bash
+convert image.png image.jpg
+```
 
 If you’re dealing with PNG images, [Pngcrush](http://pmt.sourceforge.net/pngcrush/) is useful too.
 

--- a/content/blog/posts/immediately-invoked-function-expressions.md
+++ b/content/blog/posts/immediately-invoked-function-expressions.md
@@ -12,9 +12,8 @@ tags:
 A common patten in JavaScript is [immediately-invoked function expressions](http://benalman.com/news/2010/11/immediately-invoked-function-expression/), also known as self-executing anonymous functions. These allow you to create a private scope that won’t pollute the global namespace. They look like this:
 
 ```javascript
-<?php
 (function () {
-    // variables defined here are 
+    // variables defined here are
     // only visible in this scope
 }());
 ```
@@ -24,8 +23,7 @@ A common patten in JavaScript is [immediately-invoked function expressions](http
 
 Since PHP 5.3 brought along anonymous functions, the same can be done in PHP. Albeit with a slightly less elegant syntax:
 
-```javascript
-<?php
+```php
 call_user_func(function() {
     // do something
 });
@@ -38,8 +36,7 @@ Real world examples
 
 When bootstrapping a framework or CMS, you often have to setup the environment by defining some constants. With IIFEs you’re free to use variables liberally so you’re code’s easier to understand.
 
-```javascript
-<?php
+```php
 call_user_func(function() {
     // do some work, creating $result
     define('SOMETHING', $result)
@@ -49,20 +46,18 @@ call_user_func(function() {
 
 You can even return a variable from the function and assign it to a variable:
 
-```javascript
-<?php
+```php
 $var = call_user_func(function() {
-	$a = 2;
-	$b = 2;
-	return $a + $b;
+        $a = 2;
+        $b = 2;
+        return $a + $b;
 });
 ```
 
 
 Another use is registering namespaces with autoloaders (if you’re not using composer yet):
 
-```javascript
-<?php
+```php
 call_user_func(function() {
     require_once './vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
     $loader = new Symfony\Component\ClassLoader\UniversalClassLoader();
@@ -75,8 +70,7 @@ call_user_func(function() {
 
 PHP 5.5 looks like it has lots of [interesting features](http://nikic.github.com/2012/07/10/What-PHP-5-5-might-look-like.html). Hopefully one them will be better function dereferencing. If it is, we can expect to have a syntax like the following, without the ugly call to call_user_func:
 
-```javascript
-<?php
+```php
 // php 5.5?
 function() {
     // do something

--- a/content/blog/posts/psr-7.md
+++ b/content/blog/posts/psr-7.md
@@ -32,12 +32,16 @@ I wasn't sure about this but I think it's worth mentioning. It's not something t
 
 The HTTP spec says that
 
-    Cache-Control: no-cache
-    Cache-Control: private
+```http
+Cache-Control: no-cache
+Cache-Control: private
+```
 
 is the same as
 
-    Cache-Control: no-cache, private
+```http
+Cache-Control: no-cache, private
+```
 
 If a request comes in like the former, then should it be transformed into the latter by PHP when proxying the request? What about requests with different case header names? The HTTP spec is explicit in these cases and it makes sense in 99% of cases for PSR-7 to follow this. 
 

--- a/content/blog/posts/strace.md
+++ b/content/blog/posts/strace.md
@@ -7,7 +7,9 @@ tags:
 
 Quick strace command that I use all the time to see what files a process is opening:
 
-    strace -f <command> 2>&1 | grep ^open
+```sh
+strace -f <command> 2>&1 | grep ^open
+```
 
 Really useful to see what config files something is reading (and the order) or to see what PHP (or similar) files are being included.
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,7 @@
+import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
+
 export default function(eleventyConfig) {
+  eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPassthroughCopy({ public: "." });
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "@tailwindcss/typography": "^0.5.19",
         "concurrently": "^8.2.2",
         "tailwindcss": "^3.4.10"
@@ -134,6 +135,20 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
+      "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2428,6 +2443,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prr": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@tailwindcss/typography": "^0.5.19",
     "concurrently": "^8.2.2",
     "tailwindcss": "^3.4.10"


### PR DESCRIPTION
## Summary
- add the official Eleventy syntax highlighting plugin and enable it in the build
- convert indented blog snippets to fenced code blocks with explicit language tags so they highlight correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900c59c32dc832b813da47d579b7404