### PR TITLE
Include Prism CSS in Tailwind build

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,5 @@
+@import "./prism.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- import the Prism stylesheet from the Tailwind entrypoint so it is included in the compiled CSS bundle

## Testing
- npm run tailwind:build *(fails: missing optional dependency `@tailwindcss/typography` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900cc3735f0832b94a2677574336824