### PR TITLE
Import legacy TIL posts

### DIFF
--- a/content/blog/posts/2023/11/amazon-lex.md
+++ b/content/blog/posts/2023/11/amazon-lex.md
@@ -1,0 +1,46 @@
+---
+title: "Getting started with Amazon Lex"
+date: 2023-11-27
+tags:
+  - aws
+type: til
+---
+Today, I was setting up an [Amazon Lex](https://docs.aws.amazon.com/lex/) chatbot and came across a couple of challenges.
+
+In simple terms, Amazon Lex is like a more structred version of ChatGPT.
+It uses advanced natural language understanding (NLU) and automatic speech recognition (ASR) technologies.
+
+This allows developers to create interactive  chatbots that can understand and respond to user input in a meaningful way.
+What's useful about Lex over large language models like GPT and Llama is that it's much more structured and integrates seamlessly with other AWS services.
+
+## Quick start
+
+I started off from the [Create a bot from an example](https://docs.aws.amazon.com/lexv2/latest/dg/exercise-1.html) example, changing a few things as I went.
+
+1. **Set Up Bot and Intents:** First, I set up a bot named and defined an intent. This involved understanding the purpose of the bot and what kinds of user interactions it should handle. I did this through the AWS console but you can do it from the AWS CLI.
+
+2. **Develop Sample Utterances:** I then created sample phrases for the bot to pick up "I want to buy a widget" that would trigger the intent.
+
+3. **Configure Slots and Responses:** Next, I configured slots for capturing user input (like the product) and crafted appropriate responses.
+
+4. **Build and Test:** Finally, the bot was compiled and tested. I used commands like the one below to interact with the bot and refine its functionality.
+
+```bash
+aws lexv2-runtime recognize-text --bot-id SJUDNSMPVC --bot-alias-id TestAlias --locale-id 'en_GB' --session-id 'testsession' --text "I want to buy a widget"
+```
+
+## Challenges
+Developing a conversational AI isn't without its challenges. Here are a few I encountered:
+
+- **Bot Publishing Workflow:** The process has several steps, but it's efficient once you get the hang of it.
+- **IDs and Aliases:** It's crucial to keep track of different IDs and aliases to ensure everything functions correctly. Some commands take the bot ID, others take the alias. You'll get errors if you get them the wrong way round.
+- **Formatting with Placeholders:** I learned that placeholders in utterances need proper spacing to work effectively. For instance, ` {product} ` must have spaces around it.
+
+## Debugging
+
+You can get your bot IDs and then their aliases like this:
+
+```bash
+aws lexv2-models list-bots
+aws lexv2-models list-bot-aliases --bot-id SJUDNSMPVC
+```

--- a/content/blog/posts/2023/11/composer-aliases-and-patching.md
+++ b/content/blog/posts/2023/11/composer-aliases-and-patching.md
@@ -1,0 +1,86 @@
+---
+title: "Patching Transitive Dependency Vulnerabilities in PHP Projects with Composer"
+date: 2023-11-27
+tags:
+  - php
+type: til
+---
+We encountered a challenge recently with a security vulnerability in a transitive dependency.
+This was where our project depended on a library (let's call it `acme-corp/foo`),  which then depended on another library (let's call it `symfony/http-client`).
+
+So we had this structure:
+
+```
+our project
+    depends on: acme-corp/foo
+        depends on: symfony/http-client
+```
+
+When we get a vulnerability report (eg from Packagist, [local-php-security-checker](https://github.com/fabpot/local-php-security-checker) or running `composer audit`)
+then our normal step is to do a `composer update` and upgrade to a patched version.
+
+This is normally easy to do but in this case, acme-corp/foo was depending on a specific vulnerable version of symfony/http-client.
+acme-corp/foo was crucial to the project, but it hadn't been updated to address the newly discovered vulnerability.
+Faced with the need to protect the application while awaiting an official update, we explored several options.
+
+- contribute a fix to acme-corp/foo: not fast enough in our case
+- fork acme-corp/foo: an option but maintaining our own fork would be a heavy burden
+- use Composer's inline alias feature: our prefered approach
+- use Composer Patches
+
+## Composerr Inline Alias Method
+
+The [Inline Alias](https://getcomposer.org/doc/articles/aliases.md#require-inline-alias) feature in Composer was the simplest and most effective solution.
+
+It allows for specifying a different version of a package as if it were another.
+This method is particularly useful when needing to upgrade a dependency to a newer, more secure version than what is specified by another package.
+
+Here’s how it worked for us: we needed to use a secure version `4.4.20` of `symfony/http-client` while `acme-corp/foo` was still dependent on the vulnerable version `4.4.10`.
+In our `composer.json`, we specified the safe version with an alias to match the version expected by `acme-corp/foo`. It looked something like this:
+
+```json
+"require": {
+    "symfony/http-client": "4.4.20 as 4.4.10"
+}
+```
+
+After updating dependencies with `composer update`, Composer treated the secure symfony/http-client version 4.4.20 as if it were the vulnerable 4.4.10.
+This approach allowed us to quickly mitigate the security risk without waiting for an update from acme-corp/foo.
+
+The beauty of this solution lies in its simplicity and immediacy. It ensures that your project remains secure while minimizing disruption.
+Watch out though: major version changes or significant updates could introduce compatibility issues.
+
+Once acme-corp/foo catches up, we can then drop the symfony/http-client from our composer.json.
+
+## Composer Patches
+
+Another method we looked at was using [Composer Patches](https://docs.cweagans.net/composer-patches/).
+This involves applying a patch to the package directly in the vendor directory, using a plugin like [`cweagans/composer-patches`](https://github.com/cweagans/composer-patches).
+This approach is useful when specific changes or fixes are needed in a dependency but is harder to maintain than an inline alias.
+
+
+To get composer patches working, you require the composer-patches plugin, then provide a path to your own patch in the `extras` section of `composer.json`, something like this:
+
+```json
+"require": {
+    "symfony/http-client": "4.4.10",
+    "cweagans/composer-patches": "^1.7"
+},
+"extra": {
+    "patches": {
+        "symfony/http-client": {
+            "Security fix for HTTP Client": "path/to/http-client-security-fix.patch"
+        }
+    }
+}
+
+```
+
+Although we didn’t opt for this method, it's a viable alternative for situations where an inline alias might not be appropriate and is a useful feature to be aware of.
+
+## Conclusion
+
+This was a reminder of how our own security is so dependent on our vendors' security practices and reinforced the importance of being able to respond quickly to security vulnerabilities, especially when dependent on third-party packages.
+
+There's often lots of hidden features in package management tools like Composer. It's worth reading the [documentation](https://getcomposer.org/doc/) to find out what else it can do.
+It turned out that the Inline Alias method was a much simpler way to mitigate the security risk, without the overhead of maintaining a fork or relying on external maintainers.

--- a/content/blog/posts/2023/11/css-variables.md
+++ b/content/blog/posts/2023/11/css-variables.md
@@ -1,0 +1,42 @@
+---
+title: "CSS Variables"
+date: 2023-11-23
+tags:
+  - css
+type: til
+---
+## Revisiting CSS: A Pleasant Surprise
+I don't often write CSS. 
+To my surprise, I discovered that modern CSS now has its own native variables, known as Custom Properties.
+These are now widely supported across all major browsers (see the compatibility chart on [caniuse.com](https://caniuse.com/css-variables)).
+Initially, I thought things like this were only available in pre-processors like Sass.
+
+
+## Example
+For instance, the colours for this web page. I used CSS variables to define a color scheme:
+
+
+```css
+:root {
+    --color-midnight-blue: #10151e;
+    --color-white: #d4d6e1;
+}
+
+body {
+    background-color: var(--color-midnight-blue);
+    color: var(--color-white);
+}
+
+pre {
+    background-color: var(--color-white);
+    color: var(--color-midnight-blue);
+}
+```
+
+This not only makes the CSS more readable but also allows for easier theme management and dynamic styling.
+
+They're not just for colours and could be used for:
+
+- dimensions
+- fonts
+- complex calculated values

--- a/content/blog/posts/2023/11/distributing-python-packages-on-pypi.md
+++ b/content/blog/posts/2023/11/distributing-python-packages-on-pypi.md
@@ -1,0 +1,154 @@
+---
+title: "Distributing Python Packages on PyPI"
+date: 2023-11-29
+tags:
+  - python
+type: til
+---
+I ran through [Packaging Python Projects](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
+today to get [Clipea](https://github.com/dave1010/clipea) installable with `pip install clipea-cli`.
+
+(I originally wrote Clipea in PHP to get it working quickly but someone kindly [ported it](https://github.com/dave1010/clipea/pull/16) to Python.)
+
+`pip` packages are hosted by the [Python Package Index (PyPI)](https://pypi.org/).
+
+Here's the overview of the steps I took.
+
+## Building
+
+First you need to use a supported package format.
+There's a few ways to do this but `setuptools` and `setup.py` is really simple. Here's Clipea's:
+
+```python
+"""Setup file for clipea
+"""
+from setuptools import setup, find_packages
+
+with open('README.md', encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name="clipea-cli",
+    version="0.1.0",
+    description=" 📎🟢 Like Clippy but for the CLI. A blazing fast AI helper for your command line ",
+    url="https://github.com/dave1010/clipea/",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author="Dave Hulbert",
+    author_email="dave1010@gmail.com",
+    keywords='cli, ai, assistant, automation',
+    license="MIT",
+    packages=find_packages(),
+    install_requires=["llm"],
+    python_requires=">=3.10",
+    package_data={"clipea": ["*.txt", "clipea.zsh"]},
+    entry_points={"console_scripts": ["clipea = clipea.__main__:clipea_main"]},
+)
+```
+
+You can see I had to use the name "clipea-cli" as "clipea" was taken (actually clip-ea was taken but PyPI normalises names when comparing).
+
+You can then install it in development mode. This allows you to edit the package but also does all the normal setup like adding it to your path:
+
+```bash
+pip install -e .
+```
+
+## Packaging
+
+If you're happy with `setup.py` then you can start packaging it:
+
+```bash
+python3 setup.py sdist
+```
+
+This will result in a file like `dist/clipea-0.1.0.tar.gz`. This is what's going to be hosted on PyPI.
+
+### Checking your package with a Virtual Environment
+
+Ensure your the packge installs by creating a new Python virtual environment with `venv`.
+
+```bash
+mkdir clipea-test
+cd clipea-test
+python3 -m venv .
+source bin/activate
+```
+
+Then you can install your package with pip:
+
+```bash
+pip install path/to/dist/clipea-0.1.0.tar.gz
+```
+
+Ideally test it in different environments.
+
+## Set up PyPI
+
+There's 2 separate versions of PyPI: the [test one](https://test.pypi.org/) and the [live one](https://pypi.org/).
+Sign up to them both (they have separate logins and auth). There's a few steps to set up MFA and confirm
+your email address.
+
+Set up an API token in [your PyPI account](https://pypi.org/manage/account/#api-tokens) and save the secret key.
+
+## Upload to test.pypi.org
+
+Use `twine` to upload packages:
+
+```bash
+python3 -m twine upload --repository testpypi dist/clipea-0.1.0.tar.gz
+```
+
+Use `__token__` as the username and your API key as the password.
+Note that as soon as you upload a version of a package, you can't replace it, you have to bump the version number.
+
+## Test installing from test.pypi.org
+
+OK, assuming you successfully uploaded your package, you should now be able to install it with `pip`.
+Delete and remake your virtual environment, just to be sure.
+
+Then install with something like this:
+
+```bash
+python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps --no-build-isolation clipea
+```
+
+Note that test.pypi.org won't have your dependencies (`llm` in my case), so you may need to install them
+normally with pip yourself first. Double check they're in your `setup.py` too.
+
+You may also need `wheel` and `setuptools`:
+
+```bash
+python3 -m pip install wheel setuptools
+```
+
+## Check the test PyPI page and final checks
+
+At this point PyPI should will made a page for your package. You can see
+[Clipea's test package page here](https://test.pypi.org/project/clipea/).
+It took a couple of attempts to get the info right on the page.
+
+Also check things like version numbers in `setup.py`, Git tags, README.md, licence, security, etc.
+
+## Upload to pypi.org
+
+Make sure the package is well tested, as this is the point of no return:
+
+```bash
+python3 -m twine upload dist/clipea-0.1.0.tar.gz
+```
+
+(Remember to use your API key for pypi.org, note test.pypi.org!)
+
+## Installing
+
+If everything above worked then you should now be able to install your package with:
+
+```bash
+pip install clipea-cli
+```
+
+## Automating updates
+
+You'll need to go through the build, test, distribute steps manually whenever you make a change.
+Use Github Actions to automate this. (One for another day)

--- a/content/blog/posts/2023/11/docker-compose-watch.md
+++ b/content/blog/posts/2023/11/docker-compose-watch.md
@@ -1,0 +1,67 @@
+---
+title: "Using Docker Compose Watch instead of Bind Mounts"
+date: 2023-11-29
+tags:
+  - docker
+type: til
+---
+## Docker Volumes
+
+The standard way to keep files in sync between a Docker container and your host is using
+volumes. These use (normally) use [bind mounts](https://docs.docker.com/storage/bind-mounts/) under the hood.
+
+You can do this on the command line:
+
+```bash
+docker run -v /path/to/local/dir:/path/in/container [other-options] [image-name]
+```
+
+Or in a `docker-compose.yml` file:
+
+```yaml
+version: '3.3'
+services:
+  your-service:
+    image: your-image
+    volumes:
+      - /path/to/local/dir:/path/in/container
+```
+
+## Watch
+
+Docker Compose [v2.22 was released in Sept 2023](https://github.com/docker/compose/releases/tag/v2.22.0) and includes a new
+[file watching capability](https://docs.docker.com/compose/file-watch/).
+
+This allows you to easily sync just your source files to the container and then trigger commands when they change.
+This is handy as it means you can do `npm install` or `composer install` on your host and in the container and
+they can have platform-specific dependencies.
+
+Here it is in the compose file in the [`develop` section](https://docs.docker.com/compose/compose-file/develop/):
+
+```yaml
+version: '3.3'
+services:
+  your-service:
+    image: your-image
+    volumes:
+      - /path/to/local/dir:/path/in/container
+    develop:
+      watch:
+        - path: src/
+          target: /app/src/
+          action: sync
+```
+
+You can also use other actions:
+
+- `rebuild` will make Docker rebuild the container when the files change
+- `sync+restart` will make Docker sync and then reboot the container
+
+Once you have this in your compose file, just run the new command:
+
+```bash
+docker compose watch
+```
+
+and then it will keep the paths in sync, similar to if you had manually set up
+[`inotifywait`](https://linux.die.net/man/1/inotifywait) or [`fswatch`](https://github.com/emcrisostomo/fswatch).

--- a/content/blog/posts/2023/11/docker-shortcuts.md
+++ b/content/blog/posts/2023/11/docker-shortcuts.md
@@ -1,0 +1,12 @@
+---
+title: "Docker Shortcuts"
+date: 2023-11-22
+tags:
+  - docker
+type: til
+---
+Drop into bash on the most recently ran container:
+
+```bash
+docker exec -it $(docker ps -ql) bash
+```

--- a/content/blog/posts/2023/11/download-an-apk.md
+++ b/content/blog/posts/2023/11/download-an-apk.md
@@ -1,0 +1,41 @@
+---
+title: "Extracting an Installed APK from an Android Device"
+date: 2023-11-22
+tags:
+  - android
+type: til
+---
+I was trying to get a copy of an Android app APK file today.
+This can be really handy if you need to back up an app that's not on the Play Store anymore,
+or if you're trying to debug a problem and you don't have the original source code.
+It's also useful for sending an app to a device that doesn't have access to the Play Store, or for inspecting the app for security reasons.
+
+This used to be a straightforward task, but Google's shift to using Android App Bundles (AABs) has made it a bit more challenging.
+AABs are an upload format that includes all the app’s compiled code and resources,
+but they rely on Google Play to generate and sign the actual APK files that are installed on devices.
+This means you don't get a single APK file from the Play Store anymore, which adds a few extra steps to extract an APK from a device.
+
+## Steps to Extract an APK
+
+There's loads of guides online but this is what worked for me, with some help from ChatGPT.
+
+1. **Enable USB Debugging**:
+   - Go to `Settings > About phone` on your Android device.
+   - Tap `Build number` seven times to enable `Developer options`.
+   - In `Developer options`, enable `USB debugging`.
+
+2. **Install ADB**:
+   - Install Android Debug Bridge (ADB) from [Android SDK Platform-Tools](https://developer.android.com/tools) on your computer.
+
+3. **Connect Your Device**:
+   - Connect your Android device to your computer via USB.
+
+4. **Check ADB Device Connection**:
+   - Run `adb devices` in your terminal to ensure your device is properly connected.
+
+5. **Find the Package Name**:
+   - Use `adb shell pm list packages | grep [App_Name]` to find the package name of the app.
+
+6. **Extract the APK**:
+   - Find the path of the APK with `adb shell pm path [Package_Name]`.
+   - Pull the APK to your computer using `adb pull [APK_File_Path]`. This will put it in the current directory.

--- a/content/blog/posts/2023/11/gpt-4-vision.md
+++ b/content/blog/posts/2023/11/gpt-4-vision.md
@@ -1,0 +1,85 @@
+---
+title: "Exploring OpenAI's GPT-4 Vision API and a handy shell script to query it"
+date: 2023-11-22
+tags:
+  - openai
+type: til
+---
+OpenAI recently made their GPT-4-backed vision capabilities available to API developers. Here's [OpenAI's Vision API Guide](https://platform.openai.com/docs/guides/vision).
+
+After seeing this [demo on Twitter](https://twitter.com/charliebholtz/status/1724815159590293764) and examining the code [here](https://github.com/cbh123/narrator/blob/main/narrator.py), I decided to experiment with it myself.
+
+It's incredibly simple to use...
+
+The OpenAI docs provide an example with the following content:
+
+```json
+{
+  "type": "text",
+  "text": "What’s in this image?"
+},
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+  }
+}
+```
+
+This is encapsulated within their standard `messages` object, used across all their chat APIs.
+
+To use this, you need to select the `gpt-4-vision-preview` model, which is available if you have GPT-4 API access.
+
+## `gptv` shell script
+
+I created a simple shell script that calls the API with a user-provided image URL and query.
+
+First, you'll need an API key set in your shell environment. [Get your API key here](https://platform.openai.com/api-keys).
+
+```bash
+export OPENAI_API_KEY="your-secret-key"
+```
+
+Then, **[download the gptv script from this Gist](https://gist.github.com/dave1010/64332d1ede5d7e11e45d93570d973bde)**.
+
+```bash
+curl https://gist.githubusercontent.com/dave1010/64332d1ede5d7e11e45d93570d973bde/raw/789bd70a8f9b02913e61e7cd0b706481d8c9ee19/gptv -o gptv && chmod +x gptv
+```
+
+You'll also need `jq` installed (`sudo apt-get install jq` on Ubuntu or `brew install jq` on macOS).
+
+Run it by providing a prompt and a public URL to an image:
+
+```bash
+gptv 'give me some basic html and css for this web page menu' 'https://i.imgur.com/VDirZDf.png'
+```
+
+The script formats the input, calls OpenAI's API, and then displays the relevant output. It takes about 10 seconds at the moment.
+
+Here's the rendered HTML and CSS that it generated:
+
+![Generated Code Image](https://i.imgur.com/MJIadjB.png)
+
+## Future improvements
+
+- Support for uploading images directly.
+- Resize images and use the `detail` option for better analysis.
+
+## More examples
+
+`gptv 'explain this xkcd' https://imgs.xkcd.com/comics/rebuttals.png`
+
+![xkcd](https://imgs.xkcd.com/comics/rebuttals.png)
+
+    This comic is from the webcomic "xkcd" by Randall Munroe and is typically known for its satirical take on science, technology, mathematics, and relationships.
+    
+    The comic is addressing a situation that often arises in scientific and academic fields. It starts by discussing how it has become common for there to be a backlash against the prevailing consensus in a field. This dissenting view can sometimes lead researchers to ignore new evidence that does not fit with their preconceived ideas or the current contrarian viewpoint (which has itself become a kind of new 'conventional wisdom').
+    
+    The punchline of the comic, "In a field that’s been around for a while, it can be hard to figure out how many levels of rebuttal deep you are," humorously points out that in longstanding fields of study, the debates and rebuttals can become so layered and complex that it's difficult to keep track of the current state of accepted wisdom. The idea is that there's a rebuttal to the original theory, then there's a rebuttal to that rebuttal, and potentially many more layers as new evidence comes to light and new interpretations are made, creating a confusing intellectual landscape. This reflects the complexity of scientific discourse where multiple generations of theories and counter-theories can coexist.
+    
+    The image shows a chart with arrows pointing back and forth between "evidence" and a figure representing a researcher or academic, indicating the back-and-forth nature of arguments and counterarguments in a well-established field.
+
+`gptv 'which 1 should i buy?' https://i.imgur.com/ApuSMfv.png`
+
+    In terms of value per 100 grams, the 910g bottle at full price offers the best deal at 43.8p per 100g, totalling £3.99 for the entire bottle.
+    ...

--- a/content/blog/posts/2023/11/gpus-are-non-deterministic.md
+++ b/content/blog/posts/2023/11/gpus-are-non-deterministic.md
@@ -1,0 +1,16 @@
+---
+title: "GPUs are non-deterministic"
+date: 2023-11-21
+tags:
+  - gpus
+type: til
+---
+This means they can do the same calculation twice and get different answers.
+
+Be careful if you use GPUs for security related things.
+
+This is because of how floating point arithmetic works in CPUs/GPUs - the same thing that results in `0.1 + 0.2` not being equal to `0.3`.
+
+Essentially it's non-associative. That means that `(a + b) + c` is not necessarily equal to `a + (b + c)`.
+
+So because GPUs are incredibly parallel, they could do a+b+c in 2 different ways.

--- a/content/blog/posts/2023/11/how-this-works.md
+++ b/content/blog/posts/2023/11/how-this-works.md
@@ -1,0 +1,19 @@
+---
+title: "How til.dave.engineer works"
+date: 2023-11-28
+tags:
+  - til
+type: til
+---
+The site is a basic [Eleventy](https://www.11ty.dev/) site.
+You can install with `npm install` and build with `npm run build`.
+Use `npm run serve` for development.
+
+Most of the code that turns the repo of markdown files into
+a website is in [`.eleventy.js`](https://github.com/dave1010/til/blob/main/.eleventy.js).
+
+It's hosted with Github Pages and gets built using a
+[Github Action](https://github.com/dave1010/til/blob/main/.github/workflows/build.yml).
+
+This was inspired by [Simon Willison's TIL](https://til.simonwillison.net/)
+and [jbranchaud/til](https://github.com/jbranchaud/til).

--- a/content/blog/posts/2023/11/making-a-gpt.md
+++ b/content/blog/posts/2023/11/making-a-gpt.md
@@ -1,0 +1,77 @@
+---
+title: "Making a custom \"GPT\" for ChatGPT"
+date: 2023-11-28
+tags:
+  - openai
+type: til
+---
+First thing's first: GPT stands for Generative Pre-trained Transformer but for some reason OpenAI have reused the name for one of their products.
+
+## What's a Generative Pre-trained Transformer really?
+
+These are artifical neural networks that use the **Transformer** model: a highly parallel [attention](https://en.wikipedia.org/wiki/Attention_(machine_learning)) mechanism instead of 
+being a looping sequential [Recurrent Neural Network](https://en.wikipedia.org/wiki/Recurrent_neural_network) or a grid-like [Convolutional Neural Network](https://en.wikipedia.org/wiki/Convolutional_neural_network).
+
+A GPT is **pre-trained** on lots of unlabeled data, so it's unsupervised.
+
+And it's **generative** because it can generate content, rather than only being able to classify or encode.
+
+## Custom GPTs for use with ChatGPT
+
+[Open API introduced GPTs](https://openai.com/blog/introducing-gpts) on 6th November 2023. The most basic ones are nothing more than:
+
+- a system prompt
+- a logo and a description
+
+More complex ones can also include:
+
+- data you upload. Presumably this gets turned into embeddings and is accessible to ChatGPT via a vector database.
+- API access, just like ChatGPT Plugins
+
+## Making a basic GPT
+
+Making a GPT takes literally a minute or 2:
+
+1. Go to the [GPT editor](https://chat.openai.com/gpts/editor)
+2. Do what ChatGPT tells you to do:
+    - give an overview
+    - agree to a generated logo
+    - refine it
+
+Have a go, as it's so easy.
+
+## Example: [Fast GPT ⚡](https://chat.openai.com/g/g-VnlKc5BQK-fastgpt)
+
+GPT-4 can be annoyingly slow. When it waffles then its slowness is even more aparent.
+
+I made a GPT called [Fast GPT ⚡](https://chat.openai.com/g/g-VnlKc5BQK-fastgpt), which is designed to cut out all the waffle
+and get straight to the point. It works surprisingly effectively.
+
+Here's the prompt it uses:
+
+```
+FastGPT's tone is very very terse and strictly to the point.
+Be incredibly careful to ensure there are no unnecessary words at all.
+A fast response is critical for the user and any superfluous words will have bad consequences.
+This is paramount. No pleasantries. No apologising. Use very short words.
+No code comments. Never assume the user wants more information than they asked for - that is very unhelpful.
+If the user sends a message with just "?" then add more detail to your previous response,
+being as helpful as possible but still without unnecessary words.
+Multiple "?" means more verbose.
+```
+
+## How GPTs work
+
+OpenAI include the GPT prompt as part of the *system prompt* used when you converse with ChatGPT.
+Similar to custom instructions, this means that you can modify ChatGPT's system prompt,
+without having to use the [OpenAI Playground](https://platform.openai.com/playground),
+third party tools or directly access the API.
+
+ChatGPT is given the default system prompt (including how to use tools like DALL-E, its knowledge cutoff and the current date),
+followed by this, then your GPT's prompt:
+
+> You are a "GPT" – a version of ChatGPT that has been customized for a specific use case.
+> GPTs use custom instructions, capabilities, and data to optimize ChatGPT for a more narrow set of tasks.
+> You yourself are a GPT created by a user, and your name is [name].
+> Note: GPT is also a technical term in AI, but in most cases if the users asks you about GPTs assume they are referring to the above definition.
+> Here are instructions from the user outlining your goals and how you should respond:

--- a/content/blog/posts/2023/11/tidy-up-branches-in-git.md
+++ b/content/blog/posts/2023/11/tidy-up-branches-in-git.md
@@ -1,0 +1,45 @@
+---
+title: "Tidy up local and remote branches in git"
+date: 2023-11-22
+tags:
+  - git
+type: til
+---
+## Your remote tracking branches
+
+This cleans up the big origin list you get when you do `git branch --remote`
+
+```bash
+git remote prune origin
+```
+
+## Local branches that have been merged
+
+This removes your local branches that have been merged into the *current* branch.
+
+```bash
+git branch --merged | grep -v \* | xargs git branch -D
+```
+
+
+## Branches *on* the remote
+
+Remove branches that have been merged on the remote (skipping `master`)
+
+```bash
+git branch -r --merged | grep -v master | sed 's/origin\///' | xargs -n 1 git push --delete origin
+```
+
+Or if you use `main`:
+
+```bash
+git branch -r --merged | grep -v main | sed 's/origin\///' | xargs -n 1 git push --delete origin
+```
+
+## Adding a `git` alias to do all this for you
+
+Note: this assumes you're currently on `master`.
+
+```bash
+git config --global alias.cleanup-merged '!f() { git remote prune origin; git branch --merged | grep -v \* | xargs -I {} git branch -D {}; git branch -r --merged | grep -v master | sed "s/origin\///" | xargs -n 1 git push --delete origin; }; f'
+```

--- a/content/blog/posts/2023/11/vector-databases-overview.md
+++ b/content/blog/posts/2023/11/vector-databases-overview.md
@@ -1,0 +1,18 @@
+---
+title: "Vector Databases Overview"
+date: 2023-11-21
+tags:
+  - vector-databases
+type: til
+---
+I was having a look around at vector databases to have a play with document search and realised that suddenly there's support all over the place for them, even from the big players.
+
+ELI5: geo databases query 2 dimensional data, vector DBs query data with 1000+ dimensions. That means data can be related in many ways, such as word meaning.
+
+A few months back it seemed like it was just tiny startups and unstable alphas if you wanted vector DBs.
+
+- [MongoDB Atlas last month](https://www.mongodb.com/products/platform/atlas-vector-search)
+- [Elastic 2 months ago](https://www.elastic.co/enterprise-search/generative-ai) 
+- pgvector has been around for a while but 2 months ago [AWS added it to RDS](https://aws.amazon.com/about-aws/whats-new/2023/05/amazon-rds-postgresql-pgvector-ml-model-integration/)
+
+I had a play with [Chroma](https://www.trychroma.com/) - it's very quick to get started with if you want to hack around with a vector DB and see what's possible now.

--- a/content/blog/posts/2023/11/wiretap.md
+++ b/content/blog/posts/2023/11/wiretap.md
@@ -1,0 +1,47 @@
+---
+title: "Making API Specifications with Wiretap and AI"
+date: 2023-11-27
+tags:
+  - apis
+type: til
+---
+I work with APIs most days and occasionally come across one without an accurate API specification.
+  This happened recently and I thought it would be worth creating a spec before starting to use the API: that way I could make use of existing tools and libraries, rather than manually piecing together `curl` commands.
+
+My journey involved using [Wiretap](https://pb33f.io/wiretap/), an OpenAPI spec tool, in conjunction with ChatGPT and [Vacuum](https://quobix.com/vacuum/).
+
+## OpenAPI Specs
+OpenAPI specifications are the backbone of clear, consistent API development.
+They serve as a contract between the API and its consumers, ensuring reliability and consistency.
+Benefits include automated client generation, AI integration, maintaining backward compatibility, and providing clear documentation for users.
+Following the Open API spec also allows you to make use of all sorts of existing tools, which is what I was after.
+
+## Starting with ChatGPT
+Initially, I used ChatGPT to generate a basic OpenAPI spec from a handful of sample API responses. ChatGPT was great at this, writing all the standard boiler plate.
+After tweaking some assumptions that ChatGPT made and adding necessary details, I needed a robust way to validate and refine this spec. That's where Wiretap came into the picture.
+
+## Setting Up Wiretap
+Installing [Wiretap](https://pb33f.io/wiretap/) was straightforward:
+
+```bash
+brew install pb33f/taps/wiretap
+```
+
+Running Wiretap was just as simple:
+
+```bash
+wiretap -s path/to/spec.yaml -u https://api.example.com
+```
+
+This set up a local monitor at `http://localhost:9091/` and a proxy at `http://localhost:9090` for API requests.
+
+Then, all you need to do is fire requests to the localhost proxy and watch Wiretap report on any issues.
+
+## Discovering and Fixing Issues with Wiretap and Vacuum
+Wiretap proved invaluable by identifying things like an invalid response type and optional parameters in my spec.
+This prompted me to validate the spec further using the [Vacuum](https://quobix.com/vacuum/) linter, another useful tool in the API development toolkit.
+
+Once the spec was in place, it then only takes seconds to paste it into [Swagger Editor](https://editor-next.swagger.io/) (or a tool like Postman)
+and get a working API client, making it easy to explore the API. No more messing around with `curl` and manually escaped JSON!
+
+The ease and efficiency of using tools like Wiretap and AI for documentation are game-changing - gone are the days of manual labor-intensive documentation.

--- a/content/blog/posts/2024/04/alphagos-impressive-victory.md
+++ b/content/blog/posts/2024/04/alphagos-impressive-victory.md
@@ -1,0 +1,16 @@
+---
+title: "AlphaGo's Impressive Victory Over Lee Sedol"
+date: 2024-04-16
+tags:
+  - artificial-intelligence
+type: til
+---
+In 2016, DeepMind's AlphaGo program achieved a historical milestone by defeating Lee Sedol, one of the world's top Go players. While the raw skill of AlphaGo was impressive, one particularly interesting aspect was its unconventional strategy that some have described as "creative".
+
+In the second game out of 5, AlphaGo made an unusual move that deviated from traditional human strategies. Move 37 on the fifth line was a strange placement that seemed to sacrifice immediate territorial gains. However, this move was part of AlphaGo's long-term strategy to slowly accumulate advantages across the entire board.
+
+The very nature of AlphaGo's counterintuitive moves ended up having a psychological impact on Lee Sedol and he paused the game, having doubts and confusion when faced with strategies that deviated so much from traditional human play.
+
+AlphaGo was not explicitly trained to incorporate psychological strategies or to intentionally undermine its opponent's mental state. It was simply an advanced AI system focused on finding the most optimal sequence of moves to win the game through self-play and reinforcement learning algorithms.
+
+While AlphaGo's psychological effect was an unintended consequence, it raises questions about the future of AI in competitive scenarios. As AI systems become even more advanced, their ability to develop and deploy strategies that are not just mechanically superior but also psychologically disruptive could redefine the dynamics of human-machine competition across various domains.

--- a/content/blog/posts/2024/04/checking-if-a-js-module-is-being-ran-directly.md
+++ b/content/blog/posts/2024/04/checking-if-a-js-module-is-being-ran-directly.md
@@ -1,0 +1,53 @@
+---
+title: "Making JavaScript Behave Like Python for Script and Module Distinctions with Bun"
+date: 2024-04-21
+tags:
+  - javascript
+type: til
+---
+While working on a JavaScript project using the `chalk` library to stylize terminal output, I found an interesting thing about handling JavaScript files as both importable modules and executable scripts, much like Python's `if __name__ == "__main__"`.
+
+I wanted to be able to quickly test and debug a module like this:
+
+```bash
+bun run src/util/styles.ts
+# shows helpful debug info
+
+bun run src/index.ts
+# imports src/util/styles.ts but doesn't show debugging info
+```
+
+## The Solution
+Here's the code that makes it work:
+
+```javascript
+import chalk from 'chalk';
+
+const styles = {
+    error: chalk.bold.underline.red,
+    warning: chalk.italic.inverse.hex('#FFA500'),
+    info: chalk.blue
+};
+
+// Ensuring the file behaves as intended when compiled with Bun
+if (import.meta.main && import.meta.file === 'chalkStyles.ts') {
+    // Demonstrating the styles in the console
+    for (const [styleName, style] of Object.entries(styles)) {
+        console.log(`${style('This is a test!')}\t${styleName}`);
+    }
+}
+
+export default styles;
+```
+
+### Background
+In Python, it's common to use `if __name__ == "__main__"` to determine whether a script is being run standalone or being imported. I wanted to achieve something similar in JavaScript to allow for both importing styles for use in other parts of an application and running the script directly to test the styles.
+
+### The JavaScript Way
+In JavaScript, especially when using ES Modules, you can use [`import.meta.main`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta). This property is true if the script is run directly, which seemed like the perfect counterpart to Python’s approach.
+
+However, when I was compiling my JavaScript code using [Bun](https://bun.sh/) (a modern JavaScript runtime like Node.js), just using `import.meta.main` wasn't sufficient due to the way Bun handles module compilation.
+
+To accurately determine the context when compiled, I added an extra check: `import.meta.file === 'styles.ts'`. This check ensures that not only is the file executed as the main entry point, but it is also specifically the `chalkStyles.ts` file, avoiding any misinterpretation when multiple files are involved in the compilation.
+
+Implementing this dual check allowed me to flexibly use the `styles` module while quickly testing it as a standalone script.

--- a/content/blog/posts/2024/04/creating-diagrams-with-chatgpt.md
+++ b/content/blog/posts/2024/04/creating-diagrams-with-chatgpt.md
@@ -1,0 +1,103 @@
+---
+title: "Creating Diagrams with ChatGPT and Mermaid.live"
+date: 2024-04-26
+tags:
+  - diagrams
+type: til
+---
+It turns out that ChatGPT (and other large language models) are great at generating diagrams as well as text.
+
+If you ask ChatGPT to make a diagram then it might try to use Dall-e and draw one from scratch. Dall-e and other image generators aren't good at diagrams at all.
+But if you ask ChatGPT right, it can generate a good editable first draft diagram.
+
+ChatGPT has also been trained on the [Mermaid Chart](https://mermaid.js.org/) syntax. There's lots of tools that can display Mermaid charts but the quickest and easiest is [Mermaid.live](https://mermaid.live/).
+
+## Using Mermaid syntax and Mermaid.live
+
+1. Enter something like `mermaid diagram for a user MFA setup process` into ChatGPT. [Demo](https://chat.openai.com/share/06a0d00a-56a0-4c52-abe4-d8ba89504282)
+2. Copy the code it generates
+3. Paste it into [Mermaid.live](https://mermaid.live/). [Demo](https://mermaid.live/edit#pako:eNp1UkFuwjAQ_Iq15xRB0sTgQyXUpjekqBGXKhfXWcAqsVPboaWIv9dOQAJBc7J2Z2ZnJ3sAoWsEBha_OlQCXyRfG95Uiviv5cZJIVuuHFkSbsnSorltlaFV7q3DO7w8NPOGyy0p0ezu8YsAKTZaYaWG7vLh6alkZC4EWksWr3Ni0XWtZ61xQJQesWTkLdi2jmA_wKvLlRTcSX0hlDPyvEHxOYCGej7QC6N3ssYrIgmJXNnIlUPzH-ZkJL8wgHVEzMlYG9Yiqms-zpufRM-jbwFBsWA-LVWTclGSb-k2_00vzjEIlDsM8DvOg8iN4T7vC8NDwEI37Radh0IEDRq_Ve2v4xCoFbgNNlgB888aV7zbugoqdfRQ3jld7pUA5kyHEXRtzd35mICt-Nb6qv_bwA7wAyymyYgm8WxKx5N4msaPaQT7UJ6NkllMU5plGaWT6TGCX629wniU0emMjh_TbBInSRpHgLV02iyG--3PuJ_w3uODjeMfY0Tp7A)
+4. Edit it in Mermaid.live. Change themes, download or export
+
+Here's the code it makes:
+
+```dot
+sequenceDiagram
+    participant U as User
+    participant S as System
+    participant E as Email Server
+    participant P as Phone
+
+    U->>S: Access MFA setup page
+    S->>U: Request email verification
+    U->>E: Check email
+    E->>U: Provide verification code
+    U->>S: Enter verification code
+    S->>U: Email verified, request phone number
+    U->>S: Provide phone number
+    S->>P: Send SMS with verification code
+    P->>U: Receive SMS
+    U->>S: Enter SMS code
+    S->>U: Phone verified, setup complete
+```
+
+## Mermaid supports
+
+- Flowchart
+- Sequence Diagram
+- Class Diagram
+- State Diagram
+- Entity Relationship Diagram
+- User Journey
+- Gantt
+- Pie Chart
+- Quadrant Chart
+- Requirement Diagram
+- Gitgraph (Git) Diagram
+- C4 Diagram
+- Mindmaps
+- Timeline
+- Sankey
+- XYChart
+- Block Diagram
+
+
+## Examples
+
+### Sequence diagram
+
+[`mermaid diagram for a user MFA setup process`](https://chat.openai.com/share/06a0d00a-56a0-4c52-abe4-d8ba89504282) [Chart](https://mermaid.live/edit#pako:eNp1UkFuwjAQ_Iq15xQREwj1AQm16Q0pasSlysV1FrBK7NR2aCni77UTkEBATtbuzOzsZA8gdIXAwOJ3i0rgq-Rrw-tSEf813DgpZMOVI0vCLVlaNLetIrSKvXV4h5eFZlZzuSUFmt09fh4g-UYrLFXfXT7NZgUjcyHQWrJ4mxOLrm08a409ovCIJSPvwbZ1BLsBXl2upOBO6guhjJGXDYqvHtTXs56eG72TFV4RSUjkykamHJpHmJOR7MIAVhExJ2NNWIuotv48b34SPY--BQTFnPm0VEWKRUF-pNs8mp6fYxAodxjgd5wHkRvDXd4XhvuAha6bLToPhQhqNH6ryl_HIVBLcBussQTmnxWueLt1JZTq6KG8dbrYKwHMmRYjaJuKu_MxAVvxrfVV_7eBHeAXWDIaTNLhZEJpOo6n8XAUwR5YPB0P6HBKn9N44us0To4R_GntFeLBeEqTZ5qkwzSJaUojwEo6bRb9_XZn3E346PDBxvEfV9rpxA)
+
+![sequence](sequence.png)
+
+
+### Flow chart
+
+[`mermaid flowcahrt for an ecommerce refund process`](https://chat.openai.com/share/50ea95ff-9d38-47cb-8bd5-64fbd5877a89) [Chart](https://mermaid.live/edit#pako:eNp1U91v0zAQ_1csP2dVk6Zploch1myjIMY0JiFo9mDiS2vR2MEfdCXq_84lTqYWhJ9O5_t93J3d0lJxoBmtdmpfbpm25CkvJMHzdr10xqoaNHmEnw6MNRhUTvJncnFxRa7blSF2C0T7W7IXdivkkLJOS8xIrvZvjp7wGmHkK5gevWy_MA9vtOKutISzmm2AE6WJVJbgLQdTavEd-BnDveoJVmtvhuQgBfCMfHKWqOpc-tnjlqfK-XolhRXMwtAOedCqBGNOiweRm39cOukMmmQIw16VFhsh2Y40rPzBMNyMVm_OJE9yA_P7v-0_jALGz0CD5wQ--Mp73G27VLISun51pKEE0dhB97bTeOxSv5CnQ9yth_7G7Z0U3uOgz4rf_c9WtxI_2ldDdz3iw4hYGeM6BHKK6kDGx4PFNKAY1ExwfGhtBy4ozrSGgmYYcqiY29mCFvKIpcxZ9fkgS5pZ7SCgruG4q1ywjWY1zSq2M5htmKRZS19oFs8myWKaJFG0mIdpOJ0F9ECzMJ1PomkaXS7CBPNRGB8D-lspZAgn8zSKL6M4TWdpPE-SMKDAhVX6o_8L_ZfoJb71gM7H8Q8c_gBz)
+
+![flow](/diagrams/flow.png)
+
+
+### Gantt chart
+
+[`mermaid gantt chart for web app project: start today, 5 fortnightly sprints, milestone at the end`](https://chat.openai.com/share/6c95d0ec-a104-4655-a2da-0034221f41b2) [Chart](https://mermaid.live/edit#pako:eNp1ksFugzAMhl8l8jlUJIQWuE1CvSFN62HaxCVr3DYSJAhCt67quy9At7FV9cly_u93ZPsMW6sQMthL41xpiA8lHa5tW0tHyIuPoCiCPJ_enHYVkime8Y08NA3J8YiVbWo0jmy2B1R9haWZ9B1unbaGPFbSGG32U3XTtNqLGfmNTFmDdGyPHaOEh1wEoQj4khIm1B-OzznpGxwH0nOcErlz2F49_nPRnPvJvDaacfyWE_c4MeOiWy6-x8UzTly5v_MqdIWd8yOZymttZEWe8Kjx_duw9pKZj_dk3gYo1Oh3p5Vf6nmgS3AHrLGEzKcKd7KvXAmluXip7J3dnMwWMtf2SKFvhuXnWu5bWUO2k1Xnq400kJ3hA7I0XKSJYDEXIoyTJYUTZJyli5ClUSSWcbJKeXqh8Gmtx9lCpKngbNhlkrBVvKKASjvbFtPRjbc3-r-OwPCJyxc6ELiW)
+
+![gantt](/diagrams/gantt.png)
+
+
+## My old approach: Using ChatGPT and Python
+
+For completeness, [ChatGPT's code interpreter can run Python](https://medium.com/@dave1010/exploring-chatgpt-code-interpreter-5d0872d67058).
+This includes access to various Python charting libraries like:
+
+- Matplotlib
+- Graphviz
+- Pydot
+- NetworkX
+- Plotly
+- Bokeh
+- Seaborn
+
+These work fairly well, as ChatGPT is trained on writing Pytnon code to generate these. Graphviz is especially good, as it works with the DOT language, which ChatGPT is trained on.
+
+I generally find these more clunky to edit and iterate on with ChatGPT.

--- a/content/blog/posts/2024/04/dokku-setup.md
+++ b/content/blog/posts/2024/04/dokku-setup.md
@@ -1,0 +1,97 @@
+---
+title: "Dokku Setup"
+date: 2024-04-16
+tags:
+  - docker
+type: til
+---
+This is an overview of how to get a server set up running Dokku, with wildcard domains.
+
+Out the box Dokku image from DigitalOcean: https://marketplace.digitalocean.com/apps/dokku
+
+## Locally
+
+Git setup:
+
+```bash
+DOKKU_HOST=ssh.example.com
+APP_NAME=amazing-app
+
+git remote add dokku dokku@$DOKKU_HOST:$APP_NAME
+```
+
+## Project structure
+
+### PHP
+
+Symfony defaults to `./public`.
+
+```bash
+composer require symfony/apache-pack
+echo 'web: heroku-php-apache2 public/' > Procfile
+```
+
+## Deployment
+
+```bash
+git push dokku main
+```
+
+## Setting up a Dokku host
+
+### Prerequesits
+
+1. Install Dokku on a server. Eg [DigitalOcean 1-click](https://marketplace.digitalocean.com/apps/dokku).
+2. Add a wildcard A record domain. If you're using Cloudflare then add proxying.
+
+```bash
+ssh root@$DOKKU_HOST
+YOUR_NAME=dave
+DOMAIN=example.com
+
+# add your ssh key
+dokku ssh-keys:add admin_$YOUR_NAME
+
+# enable wildcard subdomains on $DOMAIN
+dokku domains:set-global $DOMAIN
+
+# postgres support
+dokku plugin:install https://github.com/dokku/dokku-postgres.git
+
+```
+
+### Creating and managing a new app
+
+```bash
+APP_NAME=amazing-app
+
+dokku apps:create $APP_NAME
+
+# shouldn't be needed
+dokku domains:add $APP_NAME $APP_NAME.$DOMAIN
+
+# DB
+dokku postgres:create db_$APP_NAME
+dokku postgres:link db_$APP_NAME $APP_NAME
+# check env is set
+dokku config:get $APP_NAME DATABASE_URL
+
+# set env vars
+dokku config:set $APP_NAME APP_ENV=prod
+```
+
+Once deployed, you may need to set up the app
+
+```bash
+dokku enter $APP_NAME doctrine:schema:create
+```
+
+## Debugging
+
+```bash
+# interactive shell
+dokku enter $APP_NAME
+
+# tail logs
+dokku logs -t $APP_NAME
+```

--- a/content/blog/posts/2024/04/large-numbers.md
+++ b/content/blog/posts/2024/04/large-numbers.md
@@ -1,0 +1,45 @@
+---
+title: "The Unimaginable Sizes of Graham's Number and Other Large Numbers"
+date: 2024-04-22
+tags:
+  - math
+type: til
+---
+I was talking to my kids about large numbers like a googol (10^100) and a googolplex. I knew bits and pieces about bigger number but not enough to confidently explain it until now.
+
+## Addition, multiplication, iteration and tetration
+
+First, let's see how operations are just repeats of the previous operation.
+
+- multiplication: 3×3 is just releated addition, 3+3+3 = 9
+- exponention: 3^3 is just repeated multiplication, 3×3×3 = 27
+- tetration: 3↑↑3 is just repeated exponention, 3^3^3 = about 8 billion 
+
+## Writing a Googolplex
+
+A googolplex is an enormous number defined as 10^10^100. That's a 1 followed by a googol (10^100) zeros! It's impossible to write down in normal notation due to its sheer size.
+
+## Beyond Exponential Notation
+
+There are numbers so big that they can't be expressed using exponential notation. These require other methods, such as [Knuth's up-arrow notation](https://en.wikipedia.org/wiki/Knuth%27s_up-arrow_notation), which allows us to describe numbers that are exponentially bigger than a googolplex.
+
+
+- **3↑↑3** (3 double arrow 3) signifies a number where 3 is raised to the power of itself, repeated 27 times (since 3^3 = 27). Three to the power of three to the power of three to the power of three... (27 times). This results in 7,625,597,484,987 - about 8 billion.
+- **3↑↑↑3** (3 triple arrow 3) takes this concept to the next level by stacking a power tower of 3's that is 7,625,597,484,987 layers high. This is far more than a googolplex and is virtually incomprehensible in size. It would take about 30,000 years to say "three to the power of..." 8 billion times (trust me on this). Compare this to a googolplex, where you can say "ten to the power of ten to the power of a hundred" in 3 seconds.
+- **3↑↑↑↑3** (3 quadruple arrow 3) increases complexity further. Instead of just 8 billion 3's stacked in a power tower, there's so many 3s that it would take 30,000 years to just say how many 3's there are! If each atom in our universe could represent "3 to the power of," there still wouldn't be enough to describe how big the number is.
+
+You can see how ↑ notation can quickly lead to large numbers, even with just 4 of them.
+
+## Graham's Number
+
+Then there's Graham's number, perhaps the most famous of very very large numbers. Here's how it builds:
+
+We start off with 3↑↑↑↑3. Remember that this number takes 30,000 years to describe the the height of the power tower: the power tower isn't just billions or googols tall, it's more than the number of atoms in the universe tall.
+
+We call this g₁.
+
+The next level is g₂. This is 3, with g₁ up arrows then a other 3. You saw how quickly the numbers grew when we went from 2, to 3, to 4 up arrows. Now we're at an impossibility large number of up arrows.
+
+This process continues, where we take a number that we can't even describe with up arrows, then use that many up arrows between two 3's. 
+
+We keep doing this 64 times to get Graham's number.

--- a/content/blog/posts/2024/04/typescript-intro.md
+++ b/content/blog/posts/2024/04/typescript-intro.md
@@ -1,0 +1,43 @@
+---
+title: "Introduction to TypeScript"
+date: 2024-04-22
+tags:
+  - javascript
+type: til
+---
+I recently started work on a new project and started transitioning the JavaScript into TypeScript, so thought I'd write some notes.
+
+TypeScript is made by Microsoft and basically enhances JavaScript by adding a whole load of language features relating to types.
+
+### Why TypeScript?
+
+The main advantage of TypeScript is its ability to define types for variables and function parameters. This capability helps you ensure code behaves as expected without needing to perform lots of manual tests or debug runtime issues.
+
+If you're used to having the type safety of languages like Kotlin or Swift then TypeScript will be a welcome improvement over plain JavaScript.
+
+The coolest thing about TypeScript is that it's a superset of JavaScript. This means that your JS code is already TS! You can incrementally add types and other TypeScript syntax as you go along. Just rename your `.js` file to `.ts`.
+
+### A Simple Example
+
+Here’s a quick TypeScript snippet demonstrating a function with typed parameters and return type:
+
+```typescript
+function greet(person: string, date: Date): string {
+    return `Hello ${person}, today is ${date.toDateString()}!`;
+}
+
+console.log(greet("Dave", new Date()));
+```
+
+TypeScript has other features too, like enums, tuples and generics.
+
+### Setting Up TypeScript
+
+To get started with TypeScript, install it via npm, initialize a new project, and start converting your JavaScript files to TypeScript files:
+
+```bash
+npm install -g typescript
+tsc --init
+```
+
+This will create a new `tsconfig.json` file. You can edit your `tsconfig.json` to set up the compiler options suited for your project, and run `tsc` to compile your TypeScript code to JavaScript.

--- a/content/blog/posts/2024/04/vuls-package-vulnerability-scanner.md
+++ b/content/blog/posts/2024/04/vuls-package-vulnerability-scanner.md
@@ -1,0 +1,78 @@
+---
+title: "Setting Up Vuls for Package Vulnerability Scanning on Linux Servers"
+date: 2024-04-16
+tags:
+  - security-vulnerabilities
+type: til
+---
+When managing Linux servers, it's crucial to ensure they're free from vulnerabilities. I recently explored various package vulnerability scanners and stumbled upon Vuls, an open-source tool that impressed me with its power and simplicity. Here’s a rundown of how to set it up and what makes it stand out.
+
+## What is Vuls?
+
+[Vuls](https://vuls.io/) is a powerful vulnerability scanner designed for Linux systems. It simplifies the process of identifying security vulnerabilities by automating the scanning and reporting processes. You can run it directly on the host you're scanning or remotely, making it usable for a quick one off scan or scheduled in production.
+
+## How Vuls Works
+
+The tool operates by collecting a list of installed packages (eg the same way you use the `dpkg -l` command) and then comparing this list against a database of Common Vulnerabilities and Exposures (CVE). This comparison helps identify potential security threats present in the installed packages.
+
+## Installation Process
+
+Getting Vuls up and running involves a few straightforward steps:
+
+1. **Initial Installation**:
+   Download and run the installation script:
+   ```bash
+   wget https://raw.githubusercontent.com/vulsio/vulsctl/master/install-host/install.sh
+   sudo bash install.sh
+   ```
+
+2. **Clone the Repository**:
+   Clone the Vuls repository to your system:
+   ```bash
+   git clone https://github.com/vulsio/vulsctl.git
+   ```
+
+## Updating CVE Databases
+
+Updating the CVE databases is a critical step, though it can be time-consuming. Here’s how to do it:
+
+1. **Prepare the Update Script**:
+   Customize the update script to avoid downloading unnecessary files for other operating systems:
+   ```bash
+   cp vulsctl/install-host/update-all{,-custom-ubuntu}.sh
+   nano vulsctl/install-host/update-all-custom-ubuntu.sh
+   # Comment out the lines for operating systems you don't need
+   ```
+
+2. **Run the Update**:
+   Execute the update script and allow some time for it to complete:
+   ```bash
+   cd vulsctl/install-host
+   time sudo bash update-all-custom-ubuntu.sh
+   # real	77m29.339s
+   # user	31m17.511s
+   # sys	6m23.535s
+   ```
+
+## Configuration for Scanning
+
+To scan the localhost, ensure your configuration file is set up correctly:
+```bash
+cat config.toml
+[servers]
+
+[servers.localhost]
+host               = "127.0.0.1"
+port               = "local"
+scanMode           = ["fast"]
+```
+
+## Running the Scan
+
+Once everything is set up, running a scan is as simple as executing:
+```bash
+vuls scan
+vuls report
+```
+
+This command will start the scanning process and then provide a report detailing any found vulnerabilities, including whether a patch is available.

--- a/content/blog/posts/2024/05/aws-comparison-tables.md
+++ b/content/blog/posts/2024/05/aws-comparison-tables.md
@@ -1,0 +1,199 @@
+---
+title: "AWS Service Comparison and Cheat Sheet"
+date: 2024-05-20
+tags:
+  - aws
+type: til
+---
+*Note: these were created primarily with ChatGPT, Claude and Gemini, with a bit of back and forth prompting, pasting in AWS docs and correcting things.*
+
+## AWS main topology and infrastructure options
+
+
+| **Feature**           | **AWS Regions**                                                                 | **AWS Local Zones**                                                                     | **AWS Edge Locations**                                                        | **AWS Wavelength**                                                           | **AWS Outposts**                                                             |
+|-----------------------|---------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| **Scope**             | Geographically distinct locations with multiple Availability Zones              | Extensions of Regions in metro areas                                                    | Global locations for content delivery and caching                            | Integrated with telecom providers' 5G networks                               | AWS infrastructure deployed on-premises                                      |
+| **Purpose**           | General-purpose, high availability, fault tolerance, disaster recovery          | Low-latency access to a subset of AWS services in metro areas                           | Improve web application performance through caching                          | Ultra-low latency and high-bandwidth for 5G applications                     | Consistent hybrid experience and local processing                            |
+| **Latency**           | Varies, typically higher compared to Local Zones and Wavelength                  | Lower latency compared to Regions                                                       | Ultra-low latency for cached content                                         | Lowest possible latency by being embedded within the 5G network              | Low latency for on-premises applications                                     |
+| **Primary Use**       | Broad spectrum of applications, data storage, backups                           | Latency-sensitive applications like real-time gaming, live streaming, AR/VR             | Content delivery, web application performance                                | Real-time applications requiring ultra-low latency and high bandwidth        | Applications requiring local processing, data residency, and low-latency     |
+| **Services**          | Full range of AWS services                                                      | Subset of AWS services                                                                  | CloudFront, AWS Global Accelerator, AWS WAF, Lambda@Edge                     | Subset of AWS services (e.g., EC2, EBS, VPC)                                  | Full range of AWS services available on-premises                             |
+| **Examples**          | US East (N. Virginia), EU (Frankfurt), Asia Pacific (Tokyo)                     | Los Angeles, Boston, Miami                                                              | Over 400 locations globally                                                  | Cities with 5G coverage through telecom partners like Verizon, Vodafone      | Customer data centers, edge locations, remote facilities                     |
+| **Connectivity**      | Standard AWS global network                                                     | Connected to the nearest AWS Region                                                     | Part of AWS global network                                                   | Directly connected to telecom providers’ 5G networks                         | Connected to AWS Regions for hybrid workloads                                |
+
+
+## AWS Networking Topology, Firewalls and Routing
+
+
+| **Feature**                  | **VPC (Virtual Private Cloud)**                                      | **Security Groups**                                                     | **Network ACLs (Access Control Lists)**                                     | **Route Tables**                                                        | **Internet Gateway**                                                   | **NAT Gateway**                                                       | **Transit Gateway**                                                   | **AWS WAF (Web Application Firewall)**                                 |
+|------------------------------|---------------------------------------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------------|
+| **Scope**                    | Isolated section of AWS Cloud                                       | Instance-level firewall                                                | Subnet-level firewall                                                      | Controls routing of traffic within VPC                                  | Connects VPC to the internet                                           | Enables outbound internet traffic for instances in private subnets    | Connects multiple VPCs and on-premises networks                        | Protects web applications from common web exploits                     |
+| **Purpose**                  | Define a virtual network logically isolated from other AWS resources | Control inbound/outbound traffic for instances                          | Control inbound/outbound traffic for subnets                               | Manage routes between subnets and to external destinations              | Allow resources in a VPC to access the internet                         | Allow private subnet resources to access the internet                  | Simplify network architecture with centralized connectivity             | Protect against web exploits like SQL injection and cross-site scripting |
+| **Granularity**              | Network-wide                                                         | Instance-level                                                          | Subnet-level                                                               | VPC/subnet-level                                                       | VPC-level                                                               | Subnet-level                                                           | VPC and network-wide                                                   | Application-level                                                     |
+| **Stateful/Stateless**       | N/A                                                                  | Stateful                                                               | Stateless                                                                  | N/A                                                                     | N/A                                                                     | N/A                                                                     | N/A                                                                     | Stateful                                                               |
+| **Traffic Direction**        | Inbound and outbound                                                | Inbound and outbound                                                   | Inbound and outbound                                                       | Inbound and outbound                                                   | Outbound only                                                           | Outbound only                                                          | Inbound and outbound                                                   | Inbound and outbound                                                  |
+| **Default Behavior**         | Isolated network, no traffic allowed by default                     | Deny all inbound, allow all outbound by default                        | Allow all inbound and outbound by default                                  | Allow routing within VPC, explicit routes needed for external traffic   | No traffic allowed by default                                           | No traffic allowed by default                                          | No connectivity by default                                             | No protection by default                                               |
+| **Rules**                    | Define CIDR blocks, subnets, route tables                           | Allow rules based on IP addresses, port numbers, protocols             | Allow and deny rules based on IP addresses, port numbers, protocols        | Define routes based on IP address ranges and targets                    | N/A                                                                     | N/A                                                                     | N/A                                                                     | Rules to allow or block specific HTTP/S requests                        |
+| **Use Cases**                | Customizable network topology, security, and management             | Protect instances from unwanted traffic                                | Additional layer of security at the subnet level                           | Direct traffic within VPC and to/from external networks                 | Provide internet access to VPC resources                                | Provide internet access to private subnets                             | Simplify and manage complex network topologies                         | Protect web applications from malicious attacks                         |
+| **Examples**                 | Create VPC with public and private subnets                           | Configure Security Groups to allow SSH traffic on port 22               | Set up Network ACL to allow HTTP traffic on port 80                        | Route traffic between public subnet and internet                         | Attach Internet Gateway to VPC                                          | Deploy NAT Gateway in public subnet for private subnet access           | Connect multiple VPCs across regions for centralized control           | Apply WAF rules to protect against OWASP Top 10 vulnerabilities         |
+| **Integration**              | Integrated with other AWS services like EC2, RDS, Lambda, etc.       | Works with EC2 instances, ELB, RDS                                      | Works with VPC subnets, integrated with CloudTrail for logging             | Integrated with VPC, subnets, Internet/NAT Gateways                     | Integrated with VPC and Route Tables                                    | Integrated with VPC, Route Tables, and Security Groups                 | Integrated with VPCs, Direct Connect, and VPNs                          | Integrated with CloudFront, API Gateway, ALB, and Route 53              |
+
+
+# AWS Storage Services
+
+| **Feature**                  | **S3 (Simple Storage Service)**                        | **EBS (Elastic Block Store)**                   | **EFS (Elastic File System)**                   | **Glacier**                                   | **FSx**                                          | **EC2 Instance Store**                         | **AWS Storage Gateway**                       | **AWS File Cache**                            |
+|------------------------------|--------------------------------------------------------|-------------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
+| **Scope**                    | Object storage                                         | Block storage for EC2 instances                 | File storage                                   | Archival storage                               | Managed file systems (Windows, Lustre, etc.)   | Ephemeral block storage for EC2 instances     | Hybrid cloud storage                           | Caching for high-performance applications     |
+| **Purpose**                  | Store and retrieve any amount of data                  | Persistent block storage for EC2 instances       | Scalable file storage for multiple instances    | Long-term data archiving                       | Specialized file systems for specific use cases | Temporary storage for high I/O operations     | Integrate on-premises environments with AWS    | Cache frequently accessed data for low latency |
+| **Data Access**              | HTTP/S, REST API                                       | Attached to EC2 instances as volumes             | NFS (Network File System)                       | REST API, SDK                                  | NFS (Lustre), SMB (Windows)                    | Directly attached to EC2 instances             | NFS, SMB, iSCSI                               | NFS, SMB                                      |
+| **Durability**               | 99.999999999% (11 9's)                                 | 99.999%                                          | 99.999999999%                                   | 99.999999999%                                  | 99.999999999% (varies by FSx type)             | Data persists only during instance life        | Varies by configuration                       | 99.999999999%                                 |
+| **Availability**             | 99.99% - 99.999999999%                                 | 99.99%                                           | 99.99%                                          | 99.99%                                          | 99.99% (varies by FSx type)                    | Data persists only during instance life        | Varies by configuration                       | 99.99%                                        |
+| **Scalability**              | Virtually unlimited                                    | Up to 64 TiB per volume                         | Virtually unlimited                             | Virtually unlimited                            | Up to petabytes                                | Limited to instance type                      | Scale up by adding more gateways              | Scale by adding more cache nodes              |
+| **Performance**              | High throughput, low latency                          | High IOPS, low latency                          | Scalable throughput and IOPS                    | Varies (low retrieval times for expedited)     | High performance (varies by FSx type)          | High IOPS, low latency                        | Dependent on network and configuration        | High performance, low latency                 |
+| **Use Cases**                | Backup, archival, data lakes, big data analytics      | Databases, file systems, applications           | Big data and analytics, content management      | Long-term backups, regulatory archives         | HPC, big data analytics, Windows applications  | Caching, temporary data processing             | Backup and restore, file sharing, disaster recovery | High-speed caching for data-intensive applications |
+| **Pricing**                  | Pay-as-you-go, based on storage used                   | Pay-as-you-go, based on provisioned storage     | Pay-as-you-go, based on storage used            | Pay-as-you-go, based on storage and retrieval  | Pay-as-you-go, based on provisioned storage    | Included in EC2 instance cost                 | Pay-as-you-go, based on gateway and usage     | Pay-as-you-go, based on provisioned cache     |
+| **Integration**              | Integrated with many AWS services (Lambda, Athena)     | Integrated with EC2                             | Integrated with EC2, ECS, Lambda                | Integrated with S3 for archival                | Integrated with EC2, Direct Connect            | Integrated with EC2                            | Integrated with on-premises infrastructure    | Integrated with AWS storage services          |
+| **Management**               | Managed by AWS                                         | Managed by AWS                                  | Managed by AWS                                  | Managed by AWS                                 | Managed by AWS                                  | User-managed                                   | Managed by AWS, with on-premises deployment   | Managed by AWS                                |
+| **Examples**                 | Storing images, videos, backups, logs                  | Running databases, ERP systems                  | Shared file storage for web serving, CMS        | Archiving financial and healthcare records     | FSx for Windows (file storage), FSx for Lustre (HPC) | High-performance storage for temporary data  | File Gateway for NFS/SMB, Tape Gateway        | Caching frequently accessed data for HPC      |
+
+## AWS Database Services
+
+
+| **Feature**           | **Amazon RDS**                                                                 | **Amazon DynamoDB**                                                                   | **Amazon Aurora**                                                             | **Amazon Redshift**                                                          | **Amazon ElastiCache**                                                      | **Amazon MemoryDB for Redis**                                              | **Amazon DocumentDB**                                                      | **Amazon Keyspaces**                                                       | **Amazon Neptune**                                                          | **Amazon Timestream**                                                      | **Amazon Quantum Ledger Database (QLDB)**                                  |
+|-----------------------|--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| **Database Type**     | Relational                                                                     | NoSQL (Key-Value and Document)                                                        | Relational                                                                    | Data Warehouse                                                               | In-memory cache and store                                                   | Managed Redis-compatible in-memory database                                | Managed MongoDB-compatible document database                                | Managed Cassandra-compatible database                                       | Managed graph database                                                      | Time series                                                                 | Ledger database                                                            |
+| **Purpose**           | Traditional relational databases                                               | High-performance, scalable NoSQL                                                      | MySQL and PostgreSQL compatibility with added performance                    | Analytical queries and large-scale data processing                           | Accelerate database queries, caching                                        | Low-latency, Redis-compatible caching                                        | MongoDB workloads                                                           | Cassandra workloads                                                         | Relationship and graph-based queries                                        | Store and analyze time series data                                          | Immutable, cryptographically verifiable ledger                             |
+| **Use Cases**         | OLTP applications, transactional data                                          | Applications requiring consistent, single-digit millisecond latency at any scale      | High throughput and availability for relational workloads                    | Complex analytical queries, big data                                        | Speed up read-heavy applications, session stores                            | Real-time bidding, session caching, leaderboards                            | Content management, catalogs, user profiles                                 | IoT, messaging, gaming applications                                         | Social networks, recommendation engines, fraud detection                    | IoT applications, operational monitoring                                    | Supply chain, finance, health records                                      |
+| **Data Model**        | Tables, rows, and columns                                                      | Tables with items (key-value pairs) and attributes                                    | Tables, rows, and columns                                                    | Tables with rows and columns                                                 | Key-value store                                                             | Key-value store                                                             | Collections, documents (JSON)                                               | Tables with rows and columns                                                | Property graphs (nodes and edges)                                           | Tables with rows and columns                                                | Tables with rows and columns                                                |
+| **Scalability**       | Vertical and horizontal scaling                                                | Fully managed, automatic scaling                                                      | Auto-scaling, serverless options                                             | Scalable compute nodes and storage                                           | Cluster mode for sharding                                                   | Scalable through clustering                                                 | Auto-scaling storage                                                        | Scalable throughput and storage                                             | Scale out with read replicas                                                | Auto-scaling, serverless                                                   | Scales with ledger size                                                    |
+| **Performance**       | High performance with provisioned IOPS                                         | Single-digit millisecond response times                                               | High performance with up to 5x throughput of standard MySQL                  | High performance for analytical queries                                      | Low latency                                                                  | Microsecond read and write latencies                                        | Millisecond read and write latencies                                        | Millisecond latency                                                         | Millisecond latency                                                         | High ingestion rates and query performance                                  | High throughput                                                             |
+| **Availability**      | Multi-AZ deployments for high availability                                     | Global tables for multi-region and high availability                                  | Multi-AZ, cross-region replication                                           | Multi-AZ, fault-tolerant                                                     | Multi-AZ clusters                                                           | Multi-AZ replication                                                        | Multi-AZ, continuous backups                                                | Multi-AZ replication                                                        | Multi-AZ replication                                                        | Multi-AZ replication                                                        | Built-in multi-region availability                                          |
+| **Management**        | Fully managed, automatic backups, patching, and updates                        | Fully managed, on-demand backup and restore                                           | Fully managed, automatic backups, patching, and updates                      | Fully managed, automatic backups, patching, and updates                      | Fully managed, automatic backups, patching, and updates                      | Fully managed, automatic backups, patching, and updates                     | Fully managed, automatic backups, patching, and updates                     | Fully managed, automatic backups, patching, and updates                     | Fully managed, automatic backups, patching, and updates                     | Fully managed, automatic backups, patching, and updates                     | Fully managed, automatic backups, patching, and updates                     |
+| **Pricing**           | Pay-as-you-go, reserved instances                                              | Pay-as-you-go, provisioned throughput                                                | Pay-as-you-go, reserved instances                                            | Pay-as-you-go, reserved instances                                            | Pay-as-you-go, reserved nodes                                                | Pay-as-you-go, reserved instances                                           | Pay-as-you-go, reserved instances                                           | Pay-as-you-go, reserved instances                                           | Pay-as-you-go, reserved instances                                           | Pay-as-you-go, reserved instances                                           | Pay-as-you-go, reserved instances                                           |
+| **Examples**          | MySQL, PostgreSQL, MariaDB, Oracle, SQL Server                                 | Key-value stores, gaming leaderboards, mobile apps                                    | MySQL, PostgreSQL, Serverless, Global Databases                              | Business intelligence, complex queries                                       | Session storage, leaderboard, caching                                       | Gaming, financial services, health care applications                        | Content management systems, catalogs, user profiles                         | IoT applications, messaging, gaming applications                            | Social networks, recommendation engines, fraud detection                    | IoT sensor data, financial trading, operational monitoring                   | Supply chain tracking, financial systems, healthcare records                |
+
+ 
+## AWS Compute Services:
+
+| **Feature** | **EC2** | **Lambda** | **Fargate** | **ECS** | **EKS** | **Lightsail** |
+|--------------|----------|------------|--------------|----------|----------|-----------------|
+| **Service Type** | Virtual Machines | Serverless Functions | Serverless Containers | Container Orchestration | Kubernetes Service | Virtual Private Server |
+| **Pricing Model** | Pay per use (instance type, uptime) | Pay per use (invocations, duration) | Pay per use (vCPU, memory) | Pay per use (EC2 instances or Fargate) | Pay per use (EC2 instances, Fargate) | Fixed monthly plans |
+| **Compute Capacity** | Configurable (instance types) | Automatically scales | Configurable (vCPU, memory) | Configurable (instances, tasks) | Configurable (nodes, pods) | Fixed options (plans) |
+| **Operational Responsibility** | Server management (patching, scaling) | Fully managed | Cluster management | Cluster management | Cluster management | Fully managed |
+| **Deployment Model** | Virtual Machines | Functions (code) | Containers | Containers | Containers | Virtual Machines |
+| **Orchestration** | Manual or third-party tools | Fully managed | ECS or EKS | ECS | EKS | Manual or third-party tools |
+| **Primary Use Case** | Long-running applications, monoliths | Event-driven, short-lived tasks | Microservices, batch jobs | Containerized applications | Containerized applications, microservices | Simple web apps, blogs, websites |
+| **Integration** | Wide range of AWS services | Integrates with many AWS services | Integrates with other AWS services | Integrates with other AWS services | Integrates with other AWS services | Fewer integrations |
+| **Scalability** | Vertical (instance types), Horizontal (Auto Scaling) | Automatically scales | Horizontal scaling | Horizontal scaling | Horizontal scaling | Vertical scaling (plan changes) |
+| **Container Support** | Yes (with Docker or other tools) | No | Yes (managed containers) | Yes | Yes | Limited |
+
+
+
+## EC2 instance types
+
+| **Instance Type** | **On-Demand** | **Reserved** | **Spot** | **Dedicated Hosts** | **Dedicated Instances** | **Capacity Reserved** |
+|-------------------|----------------|---------------|-----------|--------------------|-------------------------|------------------------|
+| **Pricing** | Pay per second, no upfront cost | Upfront payment for a term, hourly usage fee | Bid-based, fluctuating price | Per-host billing, hourly rate | Per-instance billing, hourly rate | Upfront payment, hourly usage fee |
+| **Cost Savings** | - | Up to 72% discount | Up to 90% discount | - | - | Discount over On-Demand |
+| **Instance Availability** | Available as needed | Reserved capacity | Opportunistic, can be interrupted | Dedicated physical servers | Dedicated physical server capacity | Reserved capacity |
+| **Use Case** | Short-term, unpredictable workloads | Steady-state, predictable usage | Fault-tolerant, flexible workloads | Compliance, licensing, legacy apps | Compliance, licensing requirements | Predictable usage |
+| **Term Commitment** | None | 1 or 3 years | None | 3 years | None | 1 or 3 years |
+| **Instance Types** | All | Specific | Varies, based on availability | Specific | Specific | Specific |
+
+
+## AWS Services List
+
+- **SageMaker**: Managed service for building, training, and deploying machine learning models.
+- **Athena**: Query service for analyzing data in S3 using SQL.
+- **Kinesis**: Real-time data streaming service.
+- **Snowball**: Physical device for data transfer to and from AWS.
+- **Macie**: Security service that uses machine learning to discover, classify, and protect sensitive data.
+- **Glue**: Managed ETL service for preparing and transforming data.
+- **Elastic Beanstalk**: Platform as a service for deploying and scaling web applications.
+- **Fargate**: Serverless compute engine for containers.
+- **Lambda**: Run code in response to events without provisioning servers.
+- **Aurora**: High-performance, MySQL and PostgreSQL-compatible relational database.
+- **Neptune**: Managed graph database service.
+- **Lightsail**: Easy-to-use virtual private server with predictable pricing.
+- **Greengrass**: Software for running local compute, messaging, and data caching for IoT devices.
+- **Firehose**: Load streaming data into data lakes, warehouses, and analytics services.
+- **Redshift**: Managed data warehouse service.
+- **CloudFront**: Content delivery network (CDN) service.
+- **Wavelength**: Brings AWS services to the edge of the 5G network.
+- **Outposts**: Bring AWS infrastructure and services to on-premises locations.
+- **AppStream**: Stream desktop applications to any device.
+- **Chime**: Communication service for online meetings, video conferencing, and business calling.
+- **WorkSpaces**: Managed, secure cloud desktop service.
+- **Kendra**: Enterprise search service powered by machine learning.
+- **Lex**: Build conversational interfaces using voice and text.
+- **Polly**: Text-to-speech service.
+- **Transcribe**: Automatic speech recognition (ASR) service.
+- **Comprehend**: Natural language processing (NLP) service.
+- **Rekognition**: Image and video analysis service.
+- **Textract**: Extract text and data from scanned documents.
+- **Elemental**: Video processing and delivery service.
+- **Braket**: Quantum computing service.
+- **QuickSight**: Business intelligence service for data visualization.
+- **OpsWorks**: Configuration management service that uses Chef or Puppet.
+- **CodePipeline**: Continuous integration and delivery service.
+- **CodeBuild**: Fully managed build service.
+- **CodeDeploy**: Automates code deployments to any instance.
+- **CodeStar**: Unified user interface for managing software development activities.
+- **AppRunner**: Deploy and run containerized web applications and APIs.
+- **Step Functions**: Coordinate distributed applications using visual workflows.
+- **Config**: Service to assess, audit, and evaluate the configurations of your AWS resources.
+- **X-Ray**: Debug and analyze microservices applications.
+- **Elastic Transcoder**: Media transcoding service.
+- **Proton**: Automated management for container and serverless deployments.
+- **AppFlow**: Managed integration service for SaaS apps.
+- **Ground Station**: Fully managed service for satellite communications.
+- **IoT Core**: Managed cloud service for connected devices.
+- **IoT Greengrass**: Software to run local compute, messaging, and data caching for IoT devices.
+- **IoT Analytics**: Analytics service for IoT data.
+- **IoT Events**: Service for detecting and responding to events from IoT sensors.
+- **IoT SiteWise**: Collect, store, organize, and monitor data from industrial equipment.
+- **IoT Things Graph**: Service for building IoT applications with little or no code.
+- **IoT TwinMaker**: Service to create digital twins of real-world systems.
+- **Location Service**: Add location data to applications.
+- **Panorama**: Computer vision at the edge.
+- **Sumerian**: Create and run 3D, AR, and VR applications.
+- **Glue DataBrew**: Visual data preparation tool.
+- **EventBridge**: Serverless event bus for integrating applications.
+- **Systems Manager**: Unified interface for operational data from AWS services.
+- **Certificate Manager**: Provision, manage, and deploy SSL/TLS certificates.
+- **Artifact**: Access compliance reports and agreements.
+- **GuardDuty**: Threat detection service.
+- **Detective**: Investigate security issues.
+- **Security Hub**: Central security management service.
+- **Shield**: DDoS protection service.
+- **WAF**: Web application firewall.
+- **Audit Manager**: Automates evidence collection for audits.
+- **Control Tower**: Set up and govern a secure, compliant multi-account AWS environment.
+- **Service Catalog**: Create and manage catalogs of IT services.
+- **Well-Architected Tool**: Review and improve cloud architectures.
+- **Personalize**: Real-time personalization and recommendation service.
+- **Forecast**: Time-series forecasting service.
+- **DeepComposer**: Machine learning-powered music composition.
+- **DeepLens**: Deep learning-enabled video camera.
+- **DeepRacer**: Autonomous 1/18th scale race car for reinforcement learning.
+- **AWS Batch**: Run batch computing workloads.
+- **Elastic File System (EFS)**: Scalable file storage service.
+- **Elastic Load Balancing (ELB)**: Distributes incoming traffic across multiple targets.
+- **FSx for Windows File Server**: Fully managed Windows file system.
+- **FSx for Lustre**: High-performance file system integrated with S3.
+- **S3 Glacier**: Low-cost cloud storage for data archiving and backup.
+- **CloudFormation**: Infrastructure as code service.
+- **CloudTrail**: Track user activity and API usage.
+- **Elastic MapReduce (EMR)**: Managed Hadoop framework for processing big data.
+- **Managed Streaming for Apache Kafka (MSK)**: Managed Apache Kafka service.
+- **DataSync**: Automated data transfer service.
+- **Snowcone**: Small, portable edge computing and data transfer device.
+- **Snowmobile**: Exabyte-scale data transfer service.
+- **App Mesh**: Service mesh for microservices.
+- **Backup**: Centralized backup service.
+- **CloudEndure Migration**: Simplify, expedite, and automate large-scale migration to AWS.
+- **Database Migration Service (DMS)**: Migrate databases to AWS with minimal downtime.
+- **Global Accelerator**: Improve availability and performance for global applications.
+- **Snow Family**: Collective term for AWS Snowball, Snowcone, and Snowmobile devices.
+- **WorkLink**: Secure mobile access to internal web content.
+- **WorkDocs**: Secure document storage and sharing service.

--- a/content/blog/posts/2024/12/cloudflare-pages-basic-auth.md
+++ b/content/blog/posts/2024/12/cloudflare-pages-basic-auth.md
@@ -1,0 +1,98 @@
+---
+title: "Deploying a Static Site with Basic Auth on Cloudflare Pages"
+date: 2024-12-13
+tags:
+  - cloudflare
+type: til
+---
+Here's how to deploy a static HTML site on Cloudflare Pages and secure it with Basic Authentication using [middleware](https://developers.cloudflare.com/pages/functions/middleware/).
+This is simple to set up and means that people or bots can't access your site without a password.
+
+Note that Basic Authentication is... _basic_. This only provides a single user/pass combo and doesn't protect against things like timing attacks.
+Still, it's enough for some needs like preventing people stumbling on something.
+
+**0\. Prerequisits**
+
+You'll need the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) installed and authenticated with your Cloudflare account:
+
+```bash
+npm install -g wrangler
+wrangler login
+```
+
+**1\. Prepare the Project**
+
+I'm using `auth-test` for my project here. If you're copy and pasting this then find and replace that.
+
+If you haven't already, create a static site:
+
+```bash
+mkdir auth-test
+cd auth-test
+echo '<h1>Welcome to the Auth Test!</h1>' > index.html
+```
+
+Set it up as a Cloudflare Pages site:
+
+```bash
+npx wrangler pages project create auth-test
+```
+
+**2\. Add Basic Auth**
+
+We need a `_middleware.js` file, which Cloudflare will pick up automatically. 
+
+```bash
+mkdir -p functions
+touch functions/_middleware.js
+```
+
+Paste in the very basic middleware logic:
+
+```js
+export const onRequest = async (context) => {
+ const { request, env } = context;
+ const auth = request.headers.get('Authorization');
+ const [user, pass] = [env.BASIC_USER, env.BASIC_PASS];
+ if (!auth || !isValid(auth, user, pass)) {
+   return new Response('Unauthorized', {
+     status: 401,
+     headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
+   });
+ }
+ return await context.next();
+};
+
+const isValid = (auth, user, pass) => {
+ const [scheme, encoded] = auth.split(' ');
+ if (scheme !== 'Basic') return false;
+ const decoded = atob(encoded).split(':');
+ return decoded[0] === user && decoded[1] === pass;
+};
+```
+
+Cloudflare have an [example Basic Auth Worker](https://developers.cloudflare.com/workers/examples/basic-auth/) that covers
+a few more things like timing safe comparison, logging out, caching and error handling.
+
+**3\. Add Secrets for Authentication**
+
+Use Wrangler to set up  added the username and password as secrets:
+
+```bash
+npx wrangler pages secret put BASIC_USER
+npx wrangler pages secret put BASIC_PASS
+```
+
+You'll be prompted to enter the secrets. Use a password manager to generate and save them.
+
+**4\. Deploy the Site**
+
+Finally, deployed the project to Cloudflare Pages:
+
+```bash
+npx wrangler pages deploy . --project-name auth-test
+```
+
+This example deploys the current directory but you can use a git repo instead.
+
+You'll be given a URL to the site, which should have basic auth working.

--- a/scripts/import_tils.py
+++ b/scripts/import_tils.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Import Today I Learned posts from the legacy repository."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+
+DATE_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}-")
+HEADING_RE = re.compile(r"^#\s*(?P<title>.+?)\s*$")
+
+
+def yaml_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def iter_markdown_files(root: Path) -> Iterable[tuple[str, Path]]:
+    for category in sorted(root.iterdir()):
+        if not category.is_dir() or category.name.startswith("_"):
+            continue
+        for path in sorted(category.glob("*.md")):
+            yield category.name, path
+
+
+def creation_date(repo_root: Path, rel_path: Path) -> dt.date:
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            "--follow",
+            "--format=%ad",
+            "--date=iso-strict",
+            "--",
+            str(rel_path),
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"Could not determine creation date for {rel_path}")
+    created = dt.datetime.fromisoformat(lines[-1])
+    return created.date()
+
+
+def parse_title_and_body(path: Path) -> tuple[str, str]:
+    raw = path.read_text(encoding="utf-8")
+    lines = raw.splitlines()
+
+    title: str | None = None
+    body_lines: list[str] = []
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if title is None:
+            match = HEADING_RE.match(line)
+            if match:
+                title = match.group("title").strip()
+                i += 1
+                # Skip a single blank line immediately after the heading
+                if i < len(lines) and lines[i].strip() == "":
+                    i += 1
+                continue
+        body_lines.append(line)
+        i += 1
+
+    if title is None:
+        title = path.stem.replace("-", " ").strip().title()
+
+    while body_lines and body_lines[0].strip() == "":
+        body_lines.pop(0)
+    while body_lines and body_lines[-1].strip() == "":
+        body_lines.pop()
+
+    body = "\n".join(body_lines)
+    if body:
+        body += "\n"
+
+    return title, body
+
+
+def import_tils(source: Path, target: Path) -> list[Path]:
+    created_files: list[Path] = []
+    for category, path in iter_markdown_files(source):
+        slug = path.stem
+        if DATE_PREFIX.match(slug):
+            continue
+
+        rel_path = path.relative_to(source)
+        date = creation_date(source, rel_path)
+        year_dir = target / f"{date.year:04d}" / f"{date.month:02d}"
+        year_dir.mkdir(parents=True, exist_ok=True)
+
+        destination = year_dir / f"{slug}.md"
+        if destination.exists():
+            raise FileExistsError(f"Destination already exists: {destination}")
+
+        title, body = parse_title_and_body(path)
+        front_matter = [
+            "---",
+            f"title: {yaml_quote(title)}",
+            f"date: {date.isoformat()}",
+            "tags:",
+            f"  - {category}",
+            "type: til",
+            "---",
+            "",
+        ]
+
+        destination.write_text("\n".join(front_matter) + body, encoding="utf-8")
+        created_files.append(destination)
+    return created_files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="Path to the legacy TIL repository")
+    parser.add_argument(
+        "target",
+        type=Path,
+        default=Path("content/blog/posts"),
+        nargs="?",
+        help="Destination directory for imported posts",
+    )
+    args = parser.parse_args()
+
+    created = import_tils(args.source, args.target)
+    for path in created:
+        print(path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python helper to import markdown from the legacy TIL repository
- migrate 23 legacy TIL posts with `type: til` metadata and category tags
- ensure the Eleventy build succeeds with the new content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900e1030378832ba6cd2bec0ab4779f