### PR TITLE
Add global footer

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -9,8 +9,19 @@
   <link rel="icon" href="https://avatars.githubusercontent.com/u/50682?v=4">
 </head>
 <body class="h-full bg-slate-950 text-slate-100 font-sans antialiased">
-  <div class="min-h-screen">
-    {{ content | safe }}
+  <div class="min-h-screen flex flex-col">
+    <main class="flex-1">
+      {{ content | safe }}
+    </main>
+    <footer class="border-t border-slate-800 bg-slate-900/60">
+      <div class="mx-auto flex max-w-5xl flex-col gap-4 px-6 py-8 text-sm text-slate-300 sm:flex-row sm:items-center sm:justify-between">
+        <p class="text-center sm:text-left">© Dave Hulbert</p>
+        <nav class="flex justify-center gap-6 sm:justify-end">
+          <a class="transition hover:text-slate-100" href="/">Home</a>
+          <a class="transition hover:text-slate-100" href="https://github.com/dave1010/dave.engineer">GitHub</a>
+        </nav>
+      </div>
+    </footer>
   </div>
   {% if scripts %}
     {{ scripts | safe }}


### PR DESCRIPTION
## Summary
- add a persistent footer to the base layout with copyright text
- include quick links to the homepage and the GitHub repository

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900ebb8faf8832b97e891c8473a40b1