### PR TITLE
Remove Medium and TIL links from homepage

### DIFF
--- a/content/index.njk
+++ b/content/index.njk
@@ -48,19 +48,6 @@ title: Dave Hulbert - Engineer
       <h2 class="text-2xl font-semibold tracking-tight text-slate-100">Find me around the web</h2>
       <div class="mt-6 grid gap-4 sm:grid-cols-2">
         <a
-          href="https://medium.com/@dave1010"
-          target="_blank"
-          rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
-        >
-          <img src="/img/Medium_black.png" alt="Medium Icon" width="40" height="40" class="shrink-0">
-          <div>
-            <h3 class="text-xl font-semibold text-slate-100">Medium</h3>
-            <p class="mt-1 text-sm text-slate-400">Read essays on leadership, AI, and systems thinking.</p>
-          </div>
-        </a>
-
-        <a
           href="https://github.com/dave1010"
           target="_blank"
           rel="noopener"
@@ -70,19 +57,6 @@ title: Dave Hulbert - Engineer
           <div>
             <h3 class="text-xl font-semibold text-slate-100">GitHub</h3>
             <p class="mt-1 text-sm text-slate-400">Browse experiments, utilities, and longer-lived projects.</p>
-          </div>
-        </a>
-
-        <a
-          href="https://til.dave.engineer"
-          target="_blank"
-          rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
-        >
-          <img src="/img/RSS_black.png" alt="RSS Icon" width="40" height="40" class="shrink-0">
-          <div>
-            <h3 class="text-xl font-semibold text-slate-100">Today I Learned</h3>
-            <p class="mt-1 text-sm text-slate-400">A running log of the curious details I collect each day.</p>
           </div>
         </a>
 


### PR DESCRIPTION
## Summary
- remove the Medium card from the "Find me around the web" section on the homepage
- remove the Today I Learned card from the same homepage section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902709a0754832b8c3fd23b1345eee6