### PR TITLE
Add more work projects and support GitHub links

### DIFF
--- a/content/work/ceo-bench.md
+++ b/content/work/ceo-bench.md
@@ -1,0 +1,16 @@
+---
+layout: work-item.njk
+title: CEO Bench
+description: "An open benchmark that measures how well language models handle executive leadership tasks."
+websiteUrl: https://ceo-bench.dave.engineer/
+githubUrl: https://github.com/dave1010/ceo-bench
+tags:
+  - work
+order: 6
+---
+CEO Bench evaluates how reliably large language models can respond to complex leadership scenarios. The benchmark generates
+realistic executive-level questions, collects model answers, and scores them against an automatic rubric so teams can compare
+performance over time. Everything is transparent: the prompts, responses, and scoring scripts live in the open.
+
+The project is designed for iteration. Researchers can plug in new models, tweak the rubric, or propose entirely new scenarios
+via GitHub. The resulting leaderboard makes it easy to spot strengths, weaknesses, and regressions as the field advances.

--- a/content/work/clipea.md
+++ b/content/work/clipea.md
@@ -2,7 +2,7 @@
 layout: work-item.njk
 title: Clipea
 description: "Like Clippy but for the CLI. A blazing fast AI helper for your command line."
-externalUrl: https://github.com/dave1010/clipea
+githubUrl: https://github.com/dave1010/clipea
 tags:
   - work
 featured: true

--- a/content/work/conway-canvas.md
+++ b/content/work/conway-canvas.md
@@ -2,10 +2,10 @@
 layout: work-item.njk
 title: Conway's Game of Life in JS
 description: "A JavaScript canvas implementation of Conway's cellular autonoma."
-externalUrl: https://github.com/dave1010/conway-canvas
+githubUrl: https://github.com/dave1010/conway-canvas
 tags:
   - work
-order: 9
+order: 13
 ---
 A minimalist implementation of Conway's Game of Life, rendered on an HTML canvas. It's a playful exploration of emergent
 behaviour in simple systems and a handy teaching aid for explaining cellular automata.

--- a/content/work/emf-planner.md
+++ b/content/work/emf-planner.md
@@ -1,0 +1,16 @@
+---
+layout: work-item.njk
+title: EMF Planner
+description: "A festival schedule planner for Electromagnetic Field that maps talks and workshops onto a live timetable."
+websiteUrl: https://emp.dave.engineer/
+githubUrl: https://github.com/dave1010/emf-planner
+tags:
+  - work
+order: 8
+---
+EMF Planner helps attendees plan their time at Electromagnetic Field. The web app turns the sprawling festival lineup into a
+clean two-dimensional timetable, making it easy to spot overlaps, filter by interests, and pin must-see sessions. Everything
+updates as the programme shifts so you can keep your schedule accurate right up to the event.
+
+The tool is built for community contributions. Talks, workshops, and map data live in version control, and deployment happens
+through a lightweight Vercel pipeline. That makes it simple to keep the planner fresh year after year.

--- a/content/work/emoji-chaos.md
+++ b/content/work/emoji-chaos.md
@@ -2,10 +2,10 @@
 layout: work-item.njk
 title: Emoji Chaos!
 description: "A very silly VR team quiz game: point your phone at different emoji to select the right answer."
-externalUrl: https://github.com/dave1010/emoji-chaos
+githubUrl: https://github.com/dave1010/emoji-chaos
 tags:
   - work
-order: 5
+order: 9
 ---
 Emoji Chaos! is a party-friendly VR quiz where players compete by aiming their phones at floating emoji. It's chaotic, fast,
 and designed to make group trivia feel playful and immersive.

--- a/content/work/hack-the-bus.md
+++ b/content/work/hack-the-bus.md
@@ -1,0 +1,16 @@
+---
+layout: work-item.njk
+title: Hack the Bus
+description: "A real-time multiplayer security game about defending and exploiting LLM-powered transit systems."
+websiteUrl: https://hack-the-bus.dave.engineer/
+githubUrl: https://github.com/dave1010/hack-the-bus
+tags:
+  - work
+order: 7
+---
+Hack the Bus turns prompt-injection defense into a competitive sport. Two teams race in real time: the red team crafts creative
+attacks against an LLM-powered ticketing system while the blue team patches vulnerabilities and protects passengers. The gameplay
+mirrors real-world incident response, forcing players to weigh speed against safety.
+
+Building the experience required orchestrating multiple AI agents, a shared game state, and fast feedback loops so players could
+see the impact of each move. The repository includes the full ruleset plus tooling for running your own tournaments.

--- a/content/work/hubcap.md
+++ b/content/work/hubcap.md
@@ -2,7 +2,7 @@
 layout: work-item.njk
 title: Hubcap
 description: "AI agent in just 25 lines of code. It can read your code and fix your bugs or make API requests and process results, all autonomously."
-externalUrl: https://github.com/dave1010/hubcap
+githubUrl: https://github.com/dave1010/hubcap
 tags:
   - work
 featured: true

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -26,7 +26,6 @@ title: Work - Dave Hulbert
               <p class="text-sm text-slate-300">{{ item.data.description }}</p>
               {% endif %}
             </div>
-            {% if item.data.externalUrl %}
             <div class="flex flex-wrap gap-3 text-sm">
               <a
                 class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
@@ -34,17 +33,29 @@ title: Work - Dave Hulbert
               >
                 Learn more
               </a>
+              {% if item.data.websiteUrl %}
               <a
                 class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10"
-                href="{{ item.data.externalUrl }}"
+                href="{{ item.data.websiteUrl }}"
                 target="_blank"
                 rel="noopener"
               >
-                Visit project
+                Visit site
                 <span aria-hidden="true">↗</span>
               </a>
+              {% endif %}
+              {% if item.data.githubUrl %}
+              <a
+                class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+                href="{{ item.data.githubUrl }}"
+                target="_blank"
+                rel="noopener"
+              >
+                View source
+                <span aria-hidden="true">↗</span>
+              </a>
+              {% endif %}
             </div>
-            {% endif %}
           </article>
           {% endif %}
         {% endfor %}

--- a/content/work/letter-unboxed.md
+++ b/content/work/letter-unboxed.md
@@ -1,0 +1,15 @@
+---
+layout: work-item.njk
+title: Letter Unboxed
+description: "Web and CLI tools for solving the New York Times Letter Boxed puzzle."
+websiteUrl: https://letter-unboxed.dave.engineer/
+githubUrl: https://github.com/dave1010/letter-unboxed
+tags:
+  - work
+order: 5
+---
+Letter Unboxed helps puzzlers explore every possible solution to the New York Times Letter Boxed challenge. The responsive web interface makes it easy to toggle each character between available, required, or excluded states so you can quickly experiment with different strategies. Optional grouping rules ensure consecutive letters rotate through distinct sides of the box, mimicking the puzzle's official constraints.
+
+For power users, the project ships with an identical command-line interface. You can filter massive dictionaries with the same
+options as the UI, enforce starting or ending letters, and sort results by length or alphabetically. Both interfaces share the
+same filtering engine, keeping puzzle solving fast whether you prefer a browser or the terminal.

--- a/content/work/pandora.md
+++ b/content/work/pandora.md
@@ -2,7 +2,7 @@
 layout: work-item.njk
 title: Pandora
 description: "Powerful coding companion ChatGPT plugin and API: edit local files, run commands, manage Docker."
-externalUrl: https://github.com/dave1010/pandora
+githubUrl: https://github.com/dave1010/pandora
 tags:
   - work
 featured: true

--- a/content/work/php-fig-psr-8.md
+++ b/content/work/php-fig-psr-8.md
@@ -2,10 +2,10 @@
 layout: work-item.njk
 title: PHP-FIG PSR-8
 description: "The first (and maybe only) implementation of PSR-8."
-externalUrl: https://github.com/dave1010/php-fig-psr-8
+githubUrl: https://github.com/dave1010/php-fig-psr-8
 tags:
   - work
-order: 8
+order: 12
 ---
 This implementation of the proposed PSR-8 HTTP interfaces showcases how PHP applications can share request and response
 objects. It acted as a proving ground for the standard and informed feedback within the PHP-FIG community.

--- a/content/work/qwerty-braille.md
+++ b/content/work/qwerty-braille.md
@@ -2,10 +2,10 @@
 layout: work-item.njk
 title: Qwerty Braille
 description: "Use a normal keyboard to type Braille characters."
-externalUrl: https://github.com/dave1010/qwerty-braille
+githubUrl: https://github.com/dave1010/qwerty-braille
 tags:
   - work
-order: 7
+order: 11
 ---
 Qwerty Braille makes Braille input more accessible by mapping Braille chords onto a regular keyboard. It's a simple utility
 that opens up experimentation with tactile writing systems for sighted and non-sighted users alike.

--- a/content/work/tree-of-thought-prompting.md
+++ b/content/work/tree-of-thought-prompting.md
@@ -2,7 +2,7 @@
 layout: work-item.njk
 title: Tree of Thought Prompting
 description: "Experiments and a write up of a new prompting technique for Large Language Models like ChatGPT."
-externalUrl: https://github.com/dave1010/tree-of-thought-prompting
+githubUrl: https://github.com/dave1010/tree-of-thought-prompting
 tags:
   - work
 featured: true

--- a/content/work/wardley-leadership-strategies.md
+++ b/content/work/wardley-leadership-strategies.md
@@ -1,0 +1,18 @@
+---
+layout: work-item.njk
+title: Wardley Leadership Strategies
+description: "A practical, community-driven guide for applying Wardley leadership practices in the real world."
+websiteUrl: https://www.wardleyleadershipstrategies.com/
+githubUrl: https://github.com/dave1010/wardley-leadership-strategies
+tags:
+  - work
+featured: true
+order: 0
+---
+Wardley Leadership Strategies turns the theory of Wardley Maps into actionable leadership guidance. I curate and maintain the
+playbook, distilling community insights into concrete moves that leaders can try immediately. The entire site and content are
+published under a Creative Commons license so other teams can remix and build on the material.
+
+The project stays close to the community. Each pattern is tested through conversations with practitioners, and readers are
+encouraged to contribute their own tactics through GitHub. By keeping the code and content open, Wardley Leadership Strategies
+serves as both a living reference and a collaboration hub for strategic leadership experiments.

--- a/content/work/xml-data-integrity-checksum.md
+++ b/content/work/xml-data-integrity-checksum.md
@@ -2,10 +2,10 @@
 layout: work-item.njk
 title: XML Data Integrity Checksum (XDIC)
 description: "A standard for embedding checksums in XML files."
-externalUrl: https://github.com/dave1010/XML-Data-Integrity-Checksum
+githubUrl: https://github.com/dave1010/XML-Data-Integrity-Checksum
 tags:
   - work
-order: 6
+order: 10
 ---
 XML Data Integrity Checksum (XDIC) defines a lightweight approach for embedding and validating checksums directly within XML
 files. It helps teams verify the integrity of critical configuration and data exchanges without bespoke tooling.

--- a/src/layouts/work-item.njk
+++ b/src/layouts/work-item.njk
@@ -9,17 +9,30 @@ layout: base.njk
       {% if description %}
       <p class="text-lg text-slate-300">{{ description }}</p>
       {% endif %}
-      {% if externalUrl %}
-      <div>
+      {% if websiteUrl or githubUrl %}
+      <div class="flex flex-wrap gap-3 text-sm">
+        {% if websiteUrl %}
         <a
-          class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-4 py-2 text-sm font-semibold text-sky-300 transition hover:bg-sky-500/10"
-          href="{{ externalUrl }}"
+          class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-4 py-2 font-semibold text-sky-300 transition hover:bg-sky-500/10"
+          href="{{ websiteUrl }}"
           target="_blank"
           rel="noopener"
         >
-          View project
+          Visit site
           <span aria-hidden="true">↗</span>
         </a>
+        {% endif %}
+        {% if githubUrl %}
+        <a
+          class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+          href="{{ githubUrl }}"
+          target="_blank"
+          rel="noopener"
+        >
+          View source
+          <span aria-hidden="true">↗</span>
+        </a>
+        {% endif %}
       </div>
       {% endif %}
     </header>


### PR DESCRIPTION
## Summary
- add new work case studies for Wardley Leadership Strategies, Letter Unboxed, CEO Bench, Hack the Bus, and EMF Planner
- support separate website and GitHub links on work item pages with updated ordering for featured and archive listings
- refresh existing work entries to use the new githubUrl front matter property

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_69027c5d2d20832ba6f5e86e2e42a4da