### PR TITLE
Add descriptive tags to Medium-sourced blog entries

### DIFF
--- a/content/blog/posts/2012/04/science-vs-the-magic-black-box.md
+++ b/content/blog/posts/2012/04/science-vs-the-magic-black-box.md
@@ -4,7 +4,9 @@ date: 2012-04-23
 type: external
 externalUrl: https://medium.com/@dave1010/science-vs-the-magic-black-box-e5fad87e37c2
 guid: e5fad87e37c2
-tags: []
+tags:
+  - artificial-intelligence
+  - science
 excerpt: >-
   Why understanding the science behind supposedly “magical” technology matters more than trusting a mysterious black box.
 ---

--- a/content/blog/posts/2014/02/the-tech-stack-at-base.md
+++ b/content/blog/posts/2014/02/the-tech-stack-at-base.md
@@ -4,7 +4,9 @@ date: 2014-02-18
 type: external
 externalUrl: https://medium.com/@dave1010/the-tech-stack-at-base-51b25f090bfe
 guid: 51b25f090bfe
-tags: []
+tags:
+  - web
+  - frameworks
 excerpt: >-
   A look at the languages, frameworks, and hosting choices powering Base’s client projects back in 2014.
 ---

--- a/content/blog/posts/2016/05/making-innovative-r-d-work-commercially-viable.md
+++ b/content/blog/posts/2016/05/making-innovative-r-d-work-commercially-viable.md
@@ -4,7 +4,9 @@ date: 2016-05-05
 type: external
 externalUrl: https://medium.com/@dave1010/making-innovative-r-d-work-commercially-viable-3f3499b26c5f
 guid: 3f3499b26c5f
-tags: []
+tags:
+  - product-management
+  - leadership
 excerpt: >-
   How we balance research and development with product delivery so experiments translate into commercially viable software.
 ---

--- a/content/blog/posts/2016/05/using-machine-learning-to-win-at-every-casino.md
+++ b/content/blog/posts/2016/05/using-machine-learning-to-win-at-every-casino.md
@@ -4,7 +4,9 @@ date: 2016-05-09
 type: external
 externalUrl: https://medium.com/@dave1010/using-machine-learning-to-win-at-every-casino-bb7242f4af04
 guid: bb7242f4af04
-tags: []
+tags:
+  - artificial-intelligence
+  - math
 excerpt: >-
   Framing the multi-armed bandit problem for casinos—balancing exploration, exploitation, and R&D so machine learning investments pay off commercially.
 ---

--- a/content/blog/posts/2017/12/obese-ii-to-normal.md
+++ b/content/blog/posts/2017/12/obese-ii-to-normal.md
@@ -4,7 +4,9 @@ date: 2017-12-31
 type: external
 externalUrl: https://medium.com/@dave1010/obese-ii-to-normal-621129a8b89b
 guid: 621129a8b89b
-tags: []
+tags:
+  - personal
+  - health
 excerpt: >-
   Three months of focused habits helped me shed enough weight to move from the Obese II category back to a healthy range.
 ---

--- a/content/blog/posts/2018/02/whats-it-like-working-for-an-agency-turned-product-company.md
+++ b/content/blog/posts/2018/02/whats-it-like-working-for-an-agency-turned-product-company.md
@@ -4,7 +4,9 @@ date: 2018-02-27
 type: external
 externalUrl: https://medium.com/@dave1010/whats-it-like-working-for-an-agency-turned-product-company-419864020221
 guid: 419864020221
-tags: []
+tags:
+  - company-culture
+  - personal
 excerpt: >-
   Our core product Passenger has been on a growth spurt, so we’re often on the lookout for new people to join our team at Base.
 ---

--- a/content/blog/posts/2018/07/all-the-databases.md
+++ b/content/blog/posts/2018/07/all-the-databases.md
@@ -4,7 +4,9 @@ date: 2018-07-18
 type: external
 externalUrl: https://medium.com/@dave1010/all-the-databases-3beb33adaa80
 guid: 3beb33adaa80
-tags: []
+tags:
+  - databases
+  - web
 excerpt: >-
   A tour of the mix of SQL and specialist data stores Passenger relies on, and why each fits its job.
 ---

--- a/content/blog/posts/2018/09/5-things-weve-learned-so-far-by-doubling-our-engineering-team.md
+++ b/content/blog/posts/2018/09/5-things-weve-learned-so-far-by-doubling-our-engineering-team.md
@@ -4,7 +4,9 @@ date: 2018-09-07
 type: external
 externalUrl: https://medium.com/@dave1010/5-things-weve-learned-so-far-by-doubling-our-engineering-team-e40ca7d312f6
 guid: e40ca7d312f6
-tags: []
+tags:
+  - leadership
+  - company-culture
 excerpt: >-
   Lessons from expanding an engineering team tenfold over a decade.
 ---

--- a/content/blog/posts/2019/08/performance-orientated-culture.md
+++ b/content/blog/posts/2019/08/performance-orientated-culture.md
@@ -4,7 +4,9 @@ date: 2019-08-22
 type: external
 externalUrl: https://medium.com/@dave1010/performance-orientated-culture-5bdaba457f06
 guid: 5bdaba457f06
-tags: []
+tags:
+  - leadership
+  - company-culture
 excerpt: >-
   Asking what you can remove without harm is the heart of a performance culture.
 ---

--- a/content/blog/posts/2019/08/team-growth.md
+++ b/content/blog/posts/2019/08/team-growth.md
@@ -4,7 +4,9 @@ date: 2019-08-22
 type: external
 externalUrl: https://medium.com/@dave1010/team-growth-c45a26881a26
 guid: c45a26881a26
-tags: []
+tags:
+  - leadership
+  - company-culture
 excerpt: >-
   A half-finished thought on growing teams that was still worth sharing.
 ---

--- a/content/blog/posts/2020/03/effective-business-leadership-in-the-midst-of-coronavirus.md
+++ b/content/blog/posts/2020/03/effective-business-leadership-in-the-midst-of-coronavirus.md
@@ -4,7 +4,9 @@ date: 2020-03-25
 type: external
 externalUrl: https://medium.com/@dave1010/effective-business-leadership-in-the-midst-of-coronavirus-7f4378b0813e
 guid: 7f4378b0813e
-tags: []
+tags:
+  - leadership
+  - economics
 excerpt: >-
   Systems thinking and behavioural economics offer guidance for leading through the pandemic.
 ---

--- a/content/blog/posts/2020/08/mytrip-version-1.md
+++ b/content/blog/posts/2020/08/mytrip-version-1.md
@@ -4,7 +4,9 @@ date: 2020-08-12
 type: external
 externalUrl: https://medium.com/@dave1010/mytrip-version-1-79b7da1ca45b
 guid: 79b7da1ca45b
-tags: []
+tags:
+  - product-management
+  - mobile
 excerpt: >-
   Launching myTrip early let Passenger learn from real users before the app was “ready.”
 ---

--- a/content/blog/posts/2021/10/working-at-passenger.md
+++ b/content/blog/posts/2021/10/working-at-passenger.md
@@ -4,7 +4,9 @@ date: 2021-10-25
 type: external
 externalUrl: https://medium.com/@dave1010/working-at-passenger-b2bdca1fd600
 guid: b2bdca1fd600
-tags: []
+tags:
+  - company-culture
+  - personal
 excerpt: >-
   Answers to the questions engineers ask about life at Passenger.
 ---

--- a/content/blog/posts/2022/03/how-the-inevitable-cycle-of-industrialization-can-be-used-to-form-a-technology-strategy.md
+++ b/content/blog/posts/2022/03/how-the-inevitable-cycle-of-industrialization-can-be-used-to-form-a-technology-strategy.md
@@ -4,7 +4,9 @@ date: 2022-03-31
 type: external
 externalUrl: https://medium.com/@dave1010/how-the-inevitable-cycle-of-industrialization-can-be-used-to-form-a-technology-strategy-9b516aebd533
 guid: 9b516aebd533
-tags: []
+tags:
+  - technology-strategy
+  - economics
 excerpt: >-
   Clickbait title: What you think you know about technology strategy is all wrong.
 ---

--- a/content/blog/posts/2023/01/the-power-of-zero-why-simple-is-better.md
+++ b/content/blog/posts/2023/01/the-power-of-zero-why-simple-is-better.md
@@ -4,7 +4,9 @@ date: 2023-01-17
 type: external
 externalUrl: https://medium.com/@dave1010/the-power-of-zero-why-simple-is-better-e58f83a5a284
 guid: e58f83a5a284
-tags: []
+tags:
+  - software-engineering
+  - leadership
 excerpt: >-
   Failure cascades in multiplicative systems when any factor drops to zero, so design to avoid single points of failure.
 ---

--- a/content/blog/posts/2023/02/debugging-with-20-questions.md
+++ b/content/blog/posts/2023/02/debugging-with-20-questions.md
@@ -4,7 +4,9 @@ date: 2023-02-21
 type: external
 externalUrl: https://medium.com/@dave1010/debugging-with-20-questions-91d7ecbb20c5
 guid: 91d7ecbb20c5
-tags: []
+tags:
+  - debugging
+  - software-engineering
 excerpt: >-
   Borrowing the classic guessing game makes it easier to isolate software issues quickly.
 ---

--- a/content/blog/posts/2023/03/slow-is-smooth-and-smooth-is-fast.md
+++ b/content/blog/posts/2023/03/slow-is-smooth-and-smooth-is-fast.md
@@ -4,7 +4,9 @@ date: 2023-03-16
 type: external
 externalUrl: https://medium.com/@dave1010/slow-is-smooth-and-smooth-is-fast-162f45eb5b1b
 guid: 162f45eb5b1b
-tags: []
+tags:
+  - leadership
+  - company-culture
 excerpt: >-
   Fostering an environment where mistakes are less likely.
 ---

--- a/content/blog/posts/2023/05/dont-bother-with-prompt-engineering.md
+++ b/content/blog/posts/2023/05/dont-bother-with-prompt-engineering.md
@@ -4,7 +4,9 @@ date: 2023-05-09
 type: external
 externalUrl: https://medium.com/aimonks/dont-bother-with-prompt-engineering-1c53b52b048e
 guid: 1c53b52b048e
-tags: []
+tags:
+  - artificial-intelligence
+  - openai
 excerpt: >-
   Effective conversations with ChatGPT beat elaborate prompt incantations, even for serious work.
 ---

--- a/content/blog/posts/2023/05/using-tree-of-thought-prompting-to-boost-chatgpts-reasoning.md
+++ b/content/blog/posts/2023/05/using-tree-of-thought-prompting-to-boost-chatgpts-reasoning.md
@@ -4,7 +4,9 @@ date: 2023-05-22
 type: external
 externalUrl: https://medium.com/@dave1010/using-tree-of-thought-prompting-to-boost-chatgpts-reasoning-318914eb0e76
 guid: 318914eb0e76
-tags: []
+tags:
+  - artificial-intelligence
+  - openai
 excerpt: >-
   Tree-of-Thought prompting broadens ChatGPT’s reasoning by encouraging structured exploration of ideas.
 ---

--- a/content/blog/posts/2023/08/amazingly-alarming-autonomous-ai-agents.md
+++ b/content/blog/posts/2023/08/amazingly-alarming-autonomous-ai-agents.md
@@ -4,7 +4,9 @@ date: 2023-08-14
 type: external
 externalUrl: https://medium.com/@dave1010/amazingly-alarming-autonomous-ai-agents-62f8a785e4d8
 guid: 62f8a785e4d8
-tags: []
+tags:
+  - artificial-intelligence
+  - openai
 excerpt: >-
   Let’s see if we can make our own autonomous AI agent in 25 lines of code.
 ---

--- a/content/blog/posts/2023/08/exploring-chatgpt-code-interpreter.md
+++ b/content/blog/posts/2023/08/exploring-chatgpt-code-interpreter.md
@@ -4,7 +4,9 @@ date: 2023-08-04
 type: external
 externalUrl: https://medium.com/@dave1010/exploring-chatgpt-code-interpreter-5d0872d67058
 guid: 5d0872d67058
-tags: []
+tags:
+  - artificial-intelligence
+  - openai
 excerpt: >-
   ChatGPT’s Code Interpreter can do far more than Python scripts, including JavaScript, PHP, and even video processing.
 ---

--- a/content/blog/posts/2023/08/making-pandora-a-super-charged-coding-plugin-for-chatgpt.md
+++ b/content/blog/posts/2023/08/making-pandora-a-super-charged-coding-plugin-for-chatgpt.md
@@ -4,7 +4,9 @@ date: 2023-08-04
 type: external
 externalUrl: https://medium.com/@dave1010/making-pandora-a-super-charged-coding-plugin-for-chatgpt-670bbb60469d
 guid: 670bbb60469d
-tags: []
+tags:
+  - artificial-intelligence
+  - openai
 excerpt: >-
   Pandora lets ChatGPT access the internet, code in any language, access local files and install any software.
 ---

--- a/content/blog/posts/2023/11/post-quantum-cryptography-its-already-here-and-its-not-as-scary-as-it-sounds.md
+++ b/content/blog/posts/2023/11/post-quantum-cryptography-its-already-here-and-its-not-as-scary-as-it-sounds.md
@@ -4,7 +4,9 @@ date: 2023-11-11
 type: external
 externalUrl: https://medium.com/@dave1010/post-quantum-cryptography-its-already-here-and-it-s-not-as-scary-as-it-sounds-cb8ea70e8f1c
 guid: cb8ea70e8f1c
-tags: []
+tags:
+  - cryptography
+  - security-vulnerabilities
 excerpt: >-
   A beginner’s guide to building Quantum Computers, breaking encryption, and stopping quantum hackers.
 ---

--- a/content/blog/posts/2024/09/your-jagged-circle-of-competence.md
+++ b/content/blog/posts/2024/09/your-jagged-circle-of-competence.md
@@ -4,7 +4,9 @@ date: 2024-09-29
 type: external
 externalUrl: https://medium.com/@dave1010/your-jagged-circle-of-competence-4214c04cd7b8
 guid: 4214c04cd7b8
-tags: []
+tags:
+  - personal
+  - artificial-intelligence
 excerpt: >-
   Personal growth sits where human strengths and AI capabilities intersect.
 ---

--- a/content/blog/posts/2024/10/ai-as-a-tool-for-global-progress.md
+++ b/content/blog/posts/2024/10/ai-as-a-tool-for-global-progress.md
@@ -4,7 +4,9 @@ date: 2024-10-02
 type: external
 externalUrl: https://medium.com/@dave1010/ai-as-a-tool-for-global-progress-b4d8aacd239d
 guid: b4d8aacd239d
-tags: []
+tags:
+  - artificial-intelligence
+  - economics
 excerpt: >-
   AI can be a catalyst for good when we focus on amplifying its positive global impact.
 ---

--- a/content/blog/posts/2024/10/chatgpts-canvas-beta-feature-internal-details.md
+++ b/content/blog/posts/2024/10/chatgpts-canvas-beta-feature-internal-details.md
@@ -4,7 +4,9 @@ date: 2024-10-05
 type: external
 externalUrl: https://medium.com/@dave1010/chatgpts-canvas-beta-feature-internal-details-a7c1e2477149
 guid: a7c1e2477149
-tags: []
+tags:
+  - artificial-intelligence
+  - openai
 excerpt: >-
   ChatGPT’s Canvas beta brings Claude-style artifacts to OpenAI, so I explored how it works behind the scenes.
 ---


### PR DESCRIPTION
## Summary
- add leadership and culture tags to historical Medium posts so they appear in the appropriate collections
- tag AI-focused Medium write-ups with artificial-intelligence/openai for better topic filtering
- categorize remaining Medium imports with product, personal, and strategy tags to round out coverage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69027e02a4fc832b8cb49c149d28d43e