### PR TITLE
Add Blog and Work links to footer navigation

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -21,6 +21,8 @@
         <p class="text-center sm:text-left">© Dave Hulbert</p>
         <nav class="flex justify-center gap-6 sm:justify-end">
           <a class="transition hover:text-slate-100" href="/">Home</a>
+          <a class="transition hover:text-slate-100" href="/blog/">Blog</a>
+          <a class="transition hover:text-slate-100" href="/work/">Work</a>
           <a class="transition hover:text-slate-100" href="https://github.com/dave1010/dave.engineer">GitHub</a>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add footer navigation links to the blog and work sections for easier access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69027e5db810832bb37f0cb0754cb37b