### PR TITLE
Add Tools Library work entry

### DIFF
--- a/content/work/tools-library.md
+++ b/content/work/tools-library.md
@@ -10,10 +10,10 @@ order: 0.5
 ---
 The Tools Library brings together quick, focused utilities that remove friction from day-to-day development and content tasks. Most tools run entirely in the browser with no accounts or tracking, so you can convert formats, debug data, or explore ideas without sacrificing privacy.
 
-The site was inspired by [tools.simonwillison.net](https://tools.simonwillison.net/). As with Simon's , it's all open soirce and the the tools are nearly all *vibe coded*. For me, the site serves as a testbed for trying out different AI coding agents.
+The site was inspired by [tools.simonwillison.net](https://tools.simonwillison.net/). As with Simon's, it's all open source and the the tools are nearly all *vibe coded*. For me, the site serves as a testbed for trying out different AI coding agents.
 
 One of my favourite tools *is* a coding agent, of sorts: [Prompt to Web Page](https://tools.dave.engineer/tools/prompt-to-web-page/). It uses the GPT-OSS-120B LLM, running on Cerebras. Type something like
 
 > Tic tac toe but with animals
 
-and it will create a game in under 5 seconds. The tool also lets you save them as a GitHub Gist.
+and it will create a game in under 5 seconds. The tool also lets you save them as a GitHub Gist so you can share them. [Here's one I made 5 seconds ago](https://gistpreview.github.io/?291a8a1e7c1f4adc6b356e8250cad1d1).


### PR DESCRIPTION
## Summary
- add a work entry for the Tools Library with site and GitHub links
- set the ordering so it appears second in the Work listing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69029aa07b30832b9255235bb67ffdf8