### PR TITLE
Add featured work to home page and refresh work listing

### DIFF
--- a/content/index.njk
+++ b/content/index.njk
@@ -44,6 +44,73 @@ title: Dave Hulbert - Engineer
       </div>
     </section>
 
+    {% set hasFeaturedWork = false %}
+    {% for item in collections.workItems %}
+      {% if item.data.featured %}
+        {% set hasFeaturedWork = true %}
+      {% endif %}
+    {% endfor %}
+    {% if hasFeaturedWork %}
+    <section class="space-y-6">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 class="text-2xl font-semibold tracking-tight text-slate-100">Featured work</h2>
+        <a
+          class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
+          href="/work/"
+        >
+          View all work
+          <span aria-hidden="true">→</span>
+        </a>
+      </div>
+      <div class="grid gap-6 sm:grid-cols-2">
+        {% for item in collections.workItems %}
+          {% if item.data.featured %}
+        <article class="flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+          <div class="space-y-3">
+            <h3 class="text-xl font-semibold text-slate-100">
+              <a class="transition hover:text-sky-300" href="{{ item.url }}">{{ item.data.title }}</a>
+            </h3>
+            {% if item.data.description %}
+            <p class="text-sm text-slate-300">{{ item.data.description }}</p>
+            {% endif %}
+          </div>
+          <div class="flex flex-wrap gap-3 text-sm">
+            <a
+              class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+              href="{{ item.url }}"
+            >
+              Learn more
+            </a>
+            {% if item.data.websiteUrl %}
+            <a
+              class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10"
+              href="{{ item.data.websiteUrl }}"
+              target="_blank"
+              rel="noopener"
+            >
+              Visit site
+              <span aria-hidden="true">↗</span>
+            </a>
+            {% endif %}
+            {% if item.data.githubUrl %}
+            <a
+              class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+              href="{{ item.data.githubUrl }}"
+              target="_blank"
+              rel="noopener"
+            >
+              View source
+              <span aria-hidden="true">↗</span>
+            </a>
+            {% endif %}
+          </div>
+        </article>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
     <section>
       <h2 class="text-2xl font-semibold tracking-tight text-slate-100">Find me around the web</h2>
       <div class="mt-6 grid gap-4 sm:grid-cols-2">

--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -5,11 +5,20 @@ title: Work - Dave Hulbert
 <main class="px-6 py-16 sm:px-10">
   <div class="mx-auto flex max-w-5xl flex-col gap-16">
     <header class="space-y-6 text-center sm:text-left">
-      <h1 class="text-4xl font-semibold tracking-tight text-slate-100">Selected work</h1>
-      <p class="text-lg text-slate-300">
-        A collection of experiments, products, and collaborations. Featured projects showcase the tools I'm most
-        excited about right now, with more explorations listed below.
-      </p>
+      <a
+        class="mx-auto inline-flex items-center gap-2 text-sm font-medium text-sky-400 transition hover:text-sky-300 sm:mx-0"
+        href="/"
+      >
+        <span aria-hidden="true">←</span>
+        Back to home
+      </a>
+      <div class="space-y-4">
+        <h1 class="text-4xl font-semibold tracking-tight text-slate-100">Selected work</h1>
+        <p class="text-lg text-slate-300">
+          A collection of experiments, products, and collaborations. Featured projects showcase the tools I'm most
+          excited about right now, with more explorations listed below.
+        </p>
+      </div>
     </header>
 
     <section class="space-y-6">
@@ -62,20 +71,54 @@ title: Work - Dave Hulbert
       </div>
     </section>
 
-    <section class="space-y-4">
+    <section class="space-y-6">
       <h2 class="text-2xl font-semibold tracking-tight text-slate-100">More work</h2>
-      <ul class="space-y-3 text-slate-300">
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {% for item in collections.workItems %}
           {% if not item.data.featured %}
-          <li>
-            <a class="font-semibold text-slate-100 transition hover:text-sky-300" href="{{ item.url }}">{{ item.data.title }}</a>
-            {% if item.data.description %}
-            <span class="text-slate-400">— {{ item.data.description }}</span>
-            {% endif %}
-          </li>
+          <article class="flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-5 transition hover:border-slate-700 hover:bg-slate-900/60">
+            <div class="space-y-3">
+              <h3 class="text-lg font-semibold text-slate-100">
+                <a class="transition hover:text-sky-300" href="{{ item.url }}">{{ item.data.title }}</a>
+              </h3>
+              {% if item.data.description %}
+              <p class="text-sm text-slate-300">{{ item.data.description }}</p>
+              {% endif %}
+            </div>
+            <div class="mt-auto flex flex-wrap gap-3 text-xs sm:text-sm">
+              <a
+                class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+                href="{{ item.url }}"
+              >
+                Learn more
+              </a>
+              {% if item.data.websiteUrl %}
+              <a
+                class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10"
+                href="{{ item.data.websiteUrl }}"
+                target="_blank"
+                rel="noopener"
+              >
+                Visit site
+                <span aria-hidden="true">↗</span>
+              </a>
+              {% endif %}
+              {% if item.data.githubUrl %}
+              <a
+                class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+                href="{{ item.data.githubUrl }}"
+                target="_blank"
+                rel="noopener"
+              >
+                View source
+                <span aria-hidden="true">↗</span>
+              </a>
+              {% endif %}
+            </div>
+          </article>
           {% endif %}
         {% endfor %}
-      </ul>
+      </div>
     </section>
   </div>
 </main>


### PR DESCRIPTION
## Summary
- highlight featured work on the homepage with the same featured cards used on the work listing
- refresh the work index to include a back-to-home link and card layouts for every project while keeping featured items prominent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902a41a659c832b8fb78c9402dea94b