### PR TITLE
Update featured work selection

### DIFF
--- a/content/work/ceo-bench.md
+++ b/content/work/ceo-bench.md
@@ -6,7 +6,8 @@ websiteUrl: https://ceo-bench.dave.engineer/
 githubUrl: https://github.com/dave1010/ceo-bench
 tags:
   - work
-order: 6
+featured: true
+order: 3
 ---
 CEO Bench evaluates how reliably large language models can respond to complex leadership scenarios. The benchmark generates
 realistic executive-level questions, collects model answers, and scores them against an automatic rubric so teams can compare

--- a/content/work/clipea.md
+++ b/content/work/clipea.md
@@ -5,7 +5,6 @@ description: "Like Clippy but for the CLI. A blazing fast AI helper for your com
 githubUrl: https://github.com/dave1010/clipea
 tags:
   - work
-featured: true
 order: 2
 ---
 Clipea brings an AI assistant directly into the terminal. It understands the current context, suggests commands, and helps

--- a/content/work/hubcap.md
+++ b/content/work/hubcap.md
@@ -5,7 +5,6 @@ description: "AI agent in just 25 lines of code. It can read your code and fix y
 githubUrl: https://github.com/dave1010/hubcap
 tags:
   - work
-featured: true
 order: 4
 ---
 

--- a/content/work/pandora.md
+++ b/content/work/pandora.md
@@ -6,7 +6,7 @@ githubUrl: https://github.com/dave1010/pandora
 tags:
   - work
 featured: true
-order: 1
+order: 2
 ---
 
 Back in June 2023, before ChatGPT had "GPTs", OpenAI created a plugin system that allowed the model to call tools via APIs. My idea was that the most powerful and flexible tool is the command line, so why not give ChatGPT access to tyour shell?

--- a/content/work/tools-library.md
+++ b/content/work/tools-library.md
@@ -6,7 +6,8 @@ websiteUrl: https://tools.dave.engineer/
 githubUrl: https://github.com/dave1010/tools
 tags:
   - work
-order: 0.5
+featured: true
+order: 1
 ---
 The Tools Library brings together quick, focused utilities that remove friction from day-to-day development and content tasks. Most tools run entirely in the browser with no accounts or tracking, so you can convert formats, debug data, or explore ideas without sacrificing privacy.
 

--- a/content/work/tree-of-thought-prompting.md
+++ b/content/work/tree-of-thought-prompting.md
@@ -6,7 +6,7 @@ githubUrl: https://github.com/dave1010/tree-of-thought-prompting
 tags:
   - work
 featured: true
-order: 3
+order: 4
 ---
 Tree of Thought Prompting explores strategies for guiding language models through branching reasoning paths. The project
 combines research write-ups with practical experiments that showcase how structured prompts improve complex problem solving.


### PR DESCRIPTION
## Summary
- feature only the current priority projects on the Work page
- ensure Wardley Leadership Strategies, Tools Library, Pandora, CEO Bench, and Tree of Thought Prompting appear in the requested order
- remove legacy featured flags so no other projects surface as featured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902a7d97578832bb9ea34f487223620