### PR TITLE
Link work items to related blog posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Coding agent notes
 
 - Eleventy sources live in `content/`; layouts resolve to `src/layouts` and components/macros share that namespace.
-- Markdown posts belong under `content/blog/`; listing pages pull from Eleventy's collection API (see `content/blog/*.md`).
+- Markdown posts belong under `content/blog/`; listing pages pull from Eleventy's collection API (see `content/blog/*.md`). When linking to published posts, use the clean `/blog/YYYY/MM/slug/` URL structure (no `/posts` segment).
 - Tailwind styles are composed in `src/styles/tailwind.css`; build artifacts expect PostCSS via the existing npm scripts.
 - Static assets in `public/` are passthrough-copied verbatim by `eleventy.config.js`—drop compiled output there when tooling can't run inside Eleventy.
 - Syntax highlighting uses the official `@11ty/eleventy-plugin-syntaxhighlight`; remember to add matching Prism styles in `src/styles/prism.css` when introducing new languages.

--- a/content/work/clipea.md
+++ b/content/work/clipea.md
@@ -12,4 +12,4 @@ shell users automate complex tasks without leaving their workflows.
 
 Clipea was built in September 2023 and was one of the first tools of its kind. It still works well but now there are better alternatives, like Github Copilot CLI and Amazon Q CLI.
 
-I shared the packaging journey in the blog post [Distributing Python Packages on PyPI](/blog/posts/2023/11/distributing-python-packages-on-pypi/).
+I shared the packaging journey in the blog post [Distributing Python Packages on PyPI](/blog/2023/11/distributing-python-packages-on-pypi/).

--- a/content/work/hubcap.md
+++ b/content/work/hubcap.md
@@ -16,4 +16,4 @@ Hubcap works surprisingly well but isn't safe or as useful as more modern coding
 
 Hubcap demonstrates how far a compact AI agent can go in just a few lines of code.
 
-I documented the original experiments in the blog post [Amazingly Alarming Autonomous AI Agents](/blog/posts/2023/08/amazingly-alarming-autonomous-ai-agents/).
+I documented the original experiments in the blog post [Amazingly Alarming Autonomous AI Agents](/blog/2023/08/amazingly-alarming-autonomous-ai-agents/).

--- a/content/work/pandora.md
+++ b/content/work/pandora.md
@@ -16,4 +16,4 @@ run commands, manage Docker containers, send desktop notifications and manage se
 
 ChatGPT plugins have been discontinued and the world has now moved on to MCP.
 
-I wrote more about Pandora in the blog post [Making Pandora, a super-charged coding plugin for ChatGPT](/blog/posts/2023/08/making-pandora-a-super-charged-coding-plugin-for-chatgpt/).
+I wrote more about Pandora in the blog post [Making Pandora, a super-charged coding plugin for ChatGPT](/blog/2023/08/making-pandora-a-super-charged-coding-plugin-for-chatgpt/).

--- a/content/work/tree-of-thought-prompting.md
+++ b/content/work/tree-of-thought-prompting.md
@@ -11,4 +11,4 @@ order: 4
 Tree of Thought Prompting explores strategies for guiding language models through branching reasoning paths. The project
 combines research write-ups with practical experiments that showcase how structured prompts improve complex problem solving.
 
-You can dive into the research notes in the blog post [Using Tree-of-Thought Prompting to boost ChatGPT’s reasoning](/blog/posts/2023/05/using-tree-of-thought-prompting-to-boost-chatgpts-reasoning/).
+You can dive into the research notes in the blog post [Using Tree-of-Thought Prompting to boost ChatGPT’s reasoning](/blog/2023/05/using-tree-of-thought-prompting-to-boost-chatgpts-reasoning/).


### PR DESCRIPTION
## Summary
- add cross-links from Pandora, Hubcap, Clipea, and Tree of Thought work entries to their detailed blog posts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902ae3c7a18832b974854df89c82593