### PR TITLE
Refresh homepage styling with animated developer aesthetic

### DIFF
--- a/content/index.njk
+++ b/content/index.njk
@@ -2,46 +2,113 @@
 layout: base.njk
 title: Dave Hulbert - Engineer
 ---
-<main class="px-6 py-16 sm:px-10">
-  <div class="mx-auto max-w-5xl space-y-16">
-    <section class="flex flex-col gap-10 lg:flex-row lg:items-center">
-      <div class="flex flex-col items-center text-center lg:w-64 lg:items-start lg:text-left">
-        <img
-          class="h-40 w-40 rounded-full border border-slate-800 shadow-2xl"
-          src="https://avatars.githubusercontent.com/u/50682?v=4"
-          alt="Dave Hulbert's Avatar"
-        >
-        <div class="mt-6 space-y-2">
-          <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl">Dave Hulbert</h1>
-          <p class="text-lg text-slate-300">Engineering leader • AI, Strategy and Compliance</p>
+<main class="relative overflow-hidden px-6 pb-24 pt-20 sm:px-10">
+  <div class="pointer-events-none absolute -left-32 top-24 h-48 w-48 rounded-full bg-sky-500/25 blur-3xl"></div>
+  <div class="pointer-events-none absolute right-0 top-56 h-64 w-64 rounded-full bg-fuchsia-500/20 blur-3xl"></div>
+  <div class="mx-auto max-w-5xl space-y-20">
+    <section class="glass-panel px-6 py-10 sm:px-12">
+      <div class="relative z-10 grid gap-10 lg:grid-cols-[minmax(0,260px)_1fr] lg:items-center">
+        <div class="flex flex-col items-center text-center lg:items-start lg:text-left">
+          <div class="relative flex h-44 w-44 items-center justify-center">
+            <div class="absolute -inset-4 rounded-[2.25rem] bg-gradient-to-br from-sky-500/30 via-sky-400/10 to-fuchsia-500/35 blur-2xl"></div>
+            <img
+              class="relative h-44 w-44 rounded-[2rem] border border-slate-700/70 object-cover shadow-2xl shadow-slate-950/60"
+              src="https://avatars.githubusercontent.com/u/50682?v=4"
+              alt="Dave Hulbert's Avatar"
+            >
+          </div>
+          <div class="mt-8 flex flex-col items-center gap-4 text-center lg:items-start lg:text-left">
+            <span class="tag-pill">Engineered leadership</span>
+            <h1 class="text-4xl font-semibold tracking-tight sm:text-5xl">Engineering clarity for complex organisations</h1>
+            <p class="max-w-xl text-lg text-slate-300">
+              I design resilient systems, shape high-trust teams, and guide responsible AI adoption so organisations can deliver with confidence.
+            </p>
+          </div>
         </div>
-      </div>
 
-      <div class="flex-1 space-y-5 text-lg text-slate-300">
-        <p>
-          I design systems and lead teams that deliver software that's trusted by millions.
-          My work spans engineering leadership, AI, strategy, software development and governance.
-        </p>
-        <p>
-          I'm currently shaping the future of public transport technology at
-          <a class="text-sky-400 hover:text-sky-300" href="https://passenger.tech/" target="_blank" rel="noopener">Passenger</a>
-          in Bournemouth, UK. Outside of work I'm fascinated by the intersection of human systems,
-          automation, and the craft of well-run teams.
-        </p>
-        <p>
-          Whether you're exploring responsible AI adoption, scaling engineering organisations, or simply
-          looking for pragmatic advice, I'd love to connect.
-        </p>
-        <div>
-          <a
-            class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
-            href="/blog/"
-          >
-            Visit the blog
-            <span aria-hidden="true">→</span>
-          </a>
+        <div class="flex flex-col gap-8 text-lg text-slate-300">
+          <p>
+            I'm currently shaping the future of public transport technology at
+            <a class="text-sky-300 transition hover:text-sky-200" href="https://passenger.tech/" target="_blank" rel="noopener">Passenger</a>
+            in Bournemouth, UK. My work bridges engineering leadership, product strategy, software governance, and AI-enabled transformation.
+          </p>
+          <p>
+            Whether you need to scale teams, prove compliance, or navigate the grey areas between human systems and automation, I love helping teams find clarity and momentum.
+          </p>
+          <div class="flex flex-wrap justify-center gap-3 text-sm text-slate-200 lg:justify-start">
+            <span class="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/70 px-3 py-1 font-medium">
+              <span class="h-2 w-2 rounded-full bg-sky-400" aria-hidden="true"></span>
+              Systems architecture
+            </span>
+            <span class="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/70 px-3 py-1 font-medium">
+              <span class="h-2 w-2 rounded-full bg-fuchsia-400" aria-hidden="true"></span>
+              Responsible AI
+            </span>
+            <span class="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/70 px-3 py-1 font-medium">
+              <span class="h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true"></span>
+              Governance & compliance
+            </span>
+            <span class="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/70 px-3 py-1 font-medium">
+              <span class="h-2 w-2 rounded-full bg-sky-200" aria-hidden="true"></span>
+              Team rituals
+            </span>
+          </div>
+          <div class="flex flex-wrap justify-center gap-4 pt-2 text-sm font-medium lg:justify-start">
+            <a
+              class="group relative inline-flex items-center gap-2 overflow-hidden rounded-full border border-sky-500/70 bg-sky-500/10 px-5 py-2 text-sky-200 transition hover:border-fuchsia-500/60 hover:text-fuchsia-200"
+              href="/work/"
+            >
+              <span class="absolute inset-0 translate-y-full bg-gradient-to-r from-sky-500/0 via-sky-500/30 to-fuchsia-500/0 opacity-0 transition duration-500 group-hover:translate-y-0 group-hover:opacity-100"></span>
+              <span class="relative">View case studies</span>
+              <span class="relative text-base" aria-hidden="true">→</span>
+            </a>
+            <a
+              class="group relative inline-flex items-center gap-2 rounded-full border border-slate-700/70 px-5 py-2 text-slate-200 transition hover:border-sky-500/60 hover:text-sky-300"
+              href="/blog/"
+            >
+              <span class="relative">Visit the blog</span>
+              <span class="relative text-base transition duration-300 group-hover:translate-x-0.5" aria-hidden="true">→</span>
+            </a>
+          </div>
+          <div class="grid gap-4 text-sm text-slate-300 sm:grid-cols-2">
+            <div class="rounded-2xl border border-slate-800/70 bg-slate-950/60 p-5">
+              <p class="font-mono text-[0.7rem] uppercase tracking-[0.32em] text-sky-300/80">Current focus</p>
+              <p class="mt-3 text-base text-slate-200">Operationalising AI safely for regulated mobility services.</p>
+            </div>
+            <div class="rounded-2xl border border-slate-800/70 bg-slate-950/60 p-5">
+              <p class="font-mono text-[0.7rem] uppercase tracking-[0.32em] text-fuchsia-300/80">Team superpower</p>
+              <p class="mt-3 text-base text-slate-200">Making complex systems legible and aligning teams around outcomes.</p>
+            </div>
+          </div>
         </div>
       </div>
+    </section>
+
+    <section class="grid gap-6 lg:grid-cols-3">
+      <article class="glass-panel p-6">
+        <div class="relative z-10 space-y-4">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-sky-500/20 font-mono text-sm uppercase tracking-[0.24em] text-sky-200">01</span>
+          <h2 class="text-lg font-semibold text-slate-100">Engineering with intent</h2>
+          <p class="text-sm text-slate-300">From architecture to delivery, I help teams connect technical decisions to measurable business outcomes.</p>
+          <p class="font-mono text-[0.7rem] uppercase tracking-[0.32em] text-slate-500">Systems & strategy</p>
+        </div>
+      </article>
+      <article class="glass-panel p-6">
+        <div class="relative z-10 space-y-4">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-fuchsia-500/20 font-mono text-sm uppercase tracking-[0.24em] text-fuchsia-200">02</span>
+          <h2 class="text-lg font-semibold text-slate-100">People, rituals, clarity</h2>
+          <p class="text-sm text-slate-300">I design operating models, coaching frameworks, and feedback loops that keep teams aligned and humane.</p>
+          <p class="font-mono text-[0.7rem] uppercase tracking-[0.32em] text-slate-500">Leadership design</p>
+        </div>
+      </article>
+      <article class="glass-panel p-6">
+        <div class="relative z-10 space-y-4">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-500/20 font-mono text-sm uppercase tracking-[0.24em] text-emerald-200">03</span>
+          <h2 class="text-lg font-semibold text-slate-100">AI, compliance & trust</h2>
+          <p class="text-sm text-slate-300">I translate regulation into actionable guardrails so AI-enabled products stay safe, transparent, and auditable.</p>
+          <p class="font-mono text-[0.7rem] uppercase tracking-[0.32em] text-slate-500">Governance</p>
+        </div>
+      </article>
     </section>
 
     {% set hasFeaturedWork = false %}
@@ -51,22 +118,26 @@ title: Dave Hulbert - Engineer
       {% endif %}
     {% endfor %}
     {% if hasFeaturedWork %}
-    <section class="space-y-6">
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h2 class="text-2xl font-semibold tracking-tight text-slate-100">Featured work</h2>
+    <section class="space-y-8">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <span class="tag-pill">Recent engagements</span>
+          <h2 class="mt-3 text-2xl font-semibold tracking-tight text-slate-100">Featured work</h2>
+          <p class="mt-2 max-w-2xl text-sm text-slate-400">Selected projects where leadership, systems thinking, and compliant delivery combined to ship trusted software.</p>
+        </div>
         <a
-          class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
+          class="group relative inline-flex items-center gap-2 rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300 transition hover:border-sky-500/70 hover:text-sky-300"
           href="/work/"
         >
-          View all work
-          <span aria-hidden="true">→</span>
+          <span class="relative">View all work</span>
+          <span class="relative text-sm" aria-hidden="true">→</span>
         </a>
       </div>
       <div class="grid gap-6 sm:grid-cols-2">
         {% for item in collections.workItems %}
           {% if item.data.featured %}
-        <article class="flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
-          <div class="space-y-3">
+        <article class="glass-panel flex h-full flex-col justify-between gap-6 p-6">
+          <div class="relative z-10 space-y-3">
             <h3 class="text-xl font-semibold text-slate-100">
               <a class="transition hover:text-sky-300" href="{{ item.url }}">{{ item.data.title }}</a>
             </h3>
@@ -74,33 +145,36 @@ title: Dave Hulbert - Engineer
             <p class="text-sm text-slate-300">{{ item.data.description }}</p>
             {% endif %}
           </div>
-          <div class="flex flex-wrap gap-3 text-sm">
+          <div class="relative z-10 flex flex-wrap gap-3 text-sm">
             <a
-              class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+              class="group relative inline-flex items-center gap-2 overflow-hidden rounded-full border border-slate-700/70 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500/70 hover:text-sky-200"
               href="{{ item.url }}"
             >
-              Learn more
+              <span class="absolute inset-0 translate-y-full bg-gradient-to-r from-sky-500/0 via-sky-500/30 to-fuchsia-500/0 opacity-0 transition duration-500 group-hover:translate-y-0 group-hover:opacity-100"></span>
+              <span class="relative">Learn more</span>
             </a>
             {% if item.data.websiteUrl %}
             <a
-              class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10"
+              class="group relative inline-flex items-center gap-2 overflow-hidden rounded-full border border-sky-500/70 px-3 py-1 font-semibold text-sky-200 transition hover:border-fuchsia-500/70 hover:text-fuchsia-200"
               href="{{ item.data.websiteUrl }}"
               target="_blank"
               rel="noopener"
             >
-              Visit site
-              <span aria-hidden="true">↗</span>
+              <span class="absolute inset-0 translate-y-full bg-gradient-to-r from-sky-500/0 via-sky-500/30 to-fuchsia-500/0 opacity-0 transition duration-500 group-hover:translate-y-0 group-hover:opacity-100"></span>
+              <span class="relative">Visit site</span>
+              <span class="relative" aria-hidden="true">↗</span>
             </a>
             {% endif %}
             {% if item.data.githubUrl %}
             <a
-              class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+              class="group relative inline-flex items-center gap-2 overflow-hidden rounded-full border border-slate-700/70 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500/70 hover:text-sky-200"
               href="{{ item.data.githubUrl }}"
               target="_blank"
               rel="noopener"
             >
-              View source
-              <span aria-hidden="true">↗</span>
+              <span class="absolute inset-0 translate-y-full bg-gradient-to-r from-sky-500/0 via-sky-500/30 to-fuchsia-500/0 opacity-0 transition duration-500 group-hover:translate-y-0 group-hover:opacity-100"></span>
+              <span class="relative">View source</span>
+              <span class="relative" aria-hidden="true">↗</span>
             </a>
             {% endif %}
           </div>
@@ -111,19 +185,23 @@ title: Dave Hulbert - Engineer
     </section>
     {% endif %}
 
-    <section>
-      <h2 class="text-2xl font-semibold tracking-tight text-slate-100">Find me around the web</h2>
-      <div class="mt-6 grid gap-4 sm:grid-cols-2">
+    <section class="space-y-6">
+      <div>
+        <span class="tag-pill">Stay connected</span>
+        <h2 class="mt-3 text-2xl font-semibold tracking-tight text-slate-100">Find me around the web</h2>
+        <p class="mt-2 max-w-2xl text-sm text-slate-400">Say hello, compare notes, or explore experiments and writing across the platforms below.</p>
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2">
         <a
           href="https://github.com/dave1010"
           target="_blank"
           rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
+          class="glass-panel group flex items-start gap-4 p-6 transition hover:border-sky-500/80 hover:text-sky-200"
         >
-          <img src="/img/Github_black.png" alt="GitHub Icon" width="40" height="40" class="shrink-0">
-          <div>
+          <img src="/img/Github_black.png" alt="GitHub Icon" width="40" height="40" class="shrink-0 opacity-90">
+          <div class="relative z-10 space-y-2">
             <h3 class="text-xl font-semibold text-slate-100">GitHub</h3>
-            <p class="mt-1 text-sm text-slate-400">Browse experiments, utilities, and longer-lived projects.</p>
+            <p class="text-sm text-slate-300">Browse experiments, utilities, and longer-lived projects.</p>
           </div>
         </a>
 
@@ -131,12 +209,12 @@ title: Dave Hulbert - Engineer
           href="https://www.linkedin.com/in/dave1010/"
           target="_blank"
           rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
+          class="glass-panel group flex items-start gap-4 p-6 transition hover:border-sky-500/80 hover:text-sky-200"
         >
-          <img src="/img/LinkedIN_black.png" alt="LinkedIn Icon" width="40" height="40" class="shrink-0">
-          <div>
+          <img src="/img/LinkedIN_black.png" alt="LinkedIn Icon" width="40" height="40" class="shrink-0 opacity-90">
+          <div class="relative z-10 space-y-2">
             <h3 class="text-xl font-semibold text-slate-100">LinkedIn</h3>
-            <p class="mt-1 text-sm text-slate-400">Say hello or talk about your next engineering challenge.</p>
+            <p class="text-sm text-slate-300">Say hello or talk about your next engineering challenge.</p>
           </div>
         </a>
 
@@ -144,12 +222,12 @@ title: Dave Hulbert - Engineer
           href="https://twitter.com/dave1010"
           target="_blank"
           rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
+          class="glass-panel group flex items-start gap-4 p-6 transition hover:border-sky-500/80 hover:text-sky-200"
         >
-          <img src="/img/Twitter_black.png" alt="Twitter Icon" width="40" height="40" class="shrink-0">
-          <div>
+          <img src="/img/Twitter_black.png" alt="Twitter Icon" width="40" height="40" class="shrink-0 opacity-90">
+          <div class="relative z-10 space-y-2">
             <h3 class="text-xl font-semibold text-slate-100">Twitter</h3>
-            <p class="mt-1 text-sm text-slate-400">Follow <code>@dave1010</code> for occasional musings.</p>
+            <p class="text-sm text-slate-300">Follow <code>@dave1010</code> for occasional musings.</p>
           </div>
         </a>
       </div>

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -11,12 +11,62 @@
     {{ headExtra | safe }}
   {% endif %}
 </head>
-<body class="h-full bg-slate-950 text-slate-100 font-sans antialiased">
+<body class="font-sans">
   <div class="min-h-screen flex flex-col">
+    <header class="sticky top-0 z-20 border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
+      <div class="mx-auto flex max-w-5xl items-center justify-between px-6 py-5">
+        <a class="group flex items-center gap-3 text-slate-200" href="/">
+          <span class="relative flex h-11 w-11 items-center justify-center overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-900/80 shadow-lg shadow-slate-950/60">
+            <span class="absolute inset-0 bg-gradient-to-br from-sky-500/30 via-transparent to-fuchsia-500/40 opacity-60 blur-xl"></span>
+            <span class="absolute inset-0 animate-[scan_8s_linear_infinite] bg-gradient-to-b from-transparent via-sky-500/30 to-transparent"></span>
+            <span class="relative font-mono text-[0.8rem] uppercase tracking-[0.3em] text-slate-100">d/e</span>
+          </span>
+          <div class="text-xs leading-snug">
+            <span class="block font-semibold tracking-wide text-slate-100">Dave Hulbert</span>
+            <span class="block text-slate-400">Engineering Leadership</span>
+          </div>
+        </a>
+        <div class="flex items-center gap-4">
+          <nav class="hidden items-center gap-7 text-sm font-medium text-slate-300 md:flex">
+            <a class="group relative transition hover:text-sky-300" href="/">
+              <span>Home</span>
+              <span class="absolute inset-x-0 -bottom-1 h-px origin-left scale-x-0 bg-gradient-to-r from-transparent via-sky-400 to-transparent transition-transform duration-300 group-hover:scale-x-100"></span>
+            </a>
+            <a class="group relative transition hover:text-sky-300" href="/blog/">
+              <span>Blog</span>
+              <span class="absolute inset-x-0 -bottom-1 h-px origin-left scale-x-0 bg-gradient-to-r from-transparent via-sky-400 to-transparent transition-transform duration-300 group-hover:scale-x-100"></span>
+            </a>
+            <a class="group relative transition hover:text-sky-300" href="/work/">
+              <span>Work</span>
+              <span class="absolute inset-x-0 -bottom-1 h-px origin-left scale-x-0 bg-gradient-to-r from-transparent via-sky-400 to-transparent transition-transform duration-300 group-hover:scale-x-100"></span>
+            </a>
+            <a class="group relative transition hover:text-sky-300" href="https://github.com/dave1010/dave.engineer">
+              <span>Repo</span>
+              <span class="absolute inset-x-0 -bottom-1 h-px origin-left scale-x-0 bg-gradient-to-r from-transparent via-sky-400 to-transparent transition-transform duration-300 group-hover:scale-x-100"></span>
+            </a>
+          </nav>
+          <nav class="flex items-center gap-4 text-[0.68rem] font-semibold uppercase tracking-[0.32em] text-slate-500 md:hidden">
+            <a class="transition hover:text-sky-300" href="/blog/">Blog</a>
+            <a class="transition hover:text-sky-300" href="/work/">Work</a>
+            <a class="transition hover:text-sky-300" href="/">Home</a>
+          </nav>
+          <a
+            class="group relative inline-flex items-center gap-2 overflow-hidden rounded-full border border-sky-500/60 bg-sky-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-sky-200 transition hover:border-fuchsia-500/60 hover:text-fuchsia-200"
+            href="https://www.linkedin.com/in/dave1010/"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="absolute inset-0 translate-y-full bg-gradient-to-r from-sky-500/0 via-sky-500/30 to-fuchsia-500/0 opacity-0 transition duration-500 group-hover:translate-y-0 group-hover:opacity-100"></span>
+            <span class="relative">Let's talk</span>
+            <span class="relative text-base" aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </div>
+    </header>
     <main class="flex-1">
       {{ content | safe }}
     </main>
-    <footer class="border-t border-slate-800 bg-slate-900/60">
+    <footer class="border-t border-slate-800/60 bg-slate-950/70 backdrop-blur">
       <div class="mx-auto flex max-w-5xl flex-col gap-4 px-6 py-8 text-sm text-slate-300 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-center sm:text-left">© Dave Hulbert <a class="font-mono text-fuchsia-400" href="/">dave.engineer</a></p>
         <nav class="flex justify-center gap-6 sm:justify-end">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -5,7 +5,123 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    color-scheme: dark;
+  }
+
   body {
-    @apply selection:bg-sky-500/30 selection:text-slate-100;
+    @apply relative min-h-screen overflow-x-hidden bg-slate-950 text-slate-100 antialiased selection:bg-sky-500/30 selection:text-slate-100;
+  }
+
+  body::before {
+    content: "";
+    position: fixed;
+    inset: -20% -30% -10% -30%;
+    background:
+      radial-gradient(circle at 10% 10%, rgba(14, 165, 233, 0.2), transparent 55%),
+      radial-gradient(circle at 90% 20%, rgba(236, 72, 153, 0.18), transparent 60%),
+      radial-gradient(circle at 40% 80%, rgba(6, 182, 212, 0.16), transparent 55%),
+      linear-gradient(120deg, rgba(15, 23, 42, 0.4), rgba(8, 47, 73, 0.2));
+    filter: blur(0px);
+    opacity: 0.85;
+    pointer-events: none;
+    z-index: -3;
+    animation: aurora 22s ease-in-out infinite alternate;
+  }
+
+  body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background-image:
+      linear-gradient(to right, rgba(100, 116, 139, 0.12) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(100, 116, 139, 0.12) 1px, transparent 1px);
+    background-size: 90px 90px;
+    mask-image: radial-gradient(circle at top, rgba(255, 255, 255, 0.2), transparent 70%);
+    opacity: 0.35;
+    pointer-events: none;
+    z-index: -2;
+    animation: drift 60s linear infinite;
+  }
+}
+
+@layer components {
+  .glass-panel {
+    @apply relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 shadow-2xl shadow-slate-950/70;
+  }
+
+  .glass-panel::before {
+    content: "";
+    position: absolute;
+    inset: -40% 10% 40% -30%;
+    background: radial-gradient(circle at top left, rgba(14, 165, 233, 0.35), transparent 55%);
+    filter: blur(40px);
+    opacity: 0.75;
+    pointer-events: none;
+    animation: aurora 18s ease-in-out infinite alternate;
+  }
+
+  .glass-panel::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(148, 163, 184, 0.08), transparent 55%);
+    pointer-events: none;
+    mix-blend-mode: screen;
+  }
+
+  .tag-pill {
+    @apply inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300 shadow-[0_0_25px_rgba(14,165,233,0.15)];
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::before,
+  body::after,
+  .glass-panel::before {
+    animation-duration: 0.001ms;
+    animation-iteration-count: 1;
+    animation-play-state: paused;
+  }
+}
+
+@keyframes aurora {
+  0% {
+    transform: translate3d(-1%, -2%, 0) scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: translate3d(2%, 2%, 0) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(-2%, 1%, 0) scale(1);
+    opacity: 0.7;
+  }
+}
+
+@keyframes drift {
+  0% {
+    background-position: 0 0, 0 0;
+  }
+  100% {
+    background-position: 180px 180px, 0 0;
+  }
+}
+
+@keyframes scan {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.6;
+  }
+  90% {
+    opacity: 0.6;
+  }
+  100% {
+    transform: translateY(200%);
+    opacity: 0;
   }
 }


### PR DESCRIPTION
## Summary
- introduce animated background, glassmorphism panels, and reusable badges for a distinctive developer aesthetic
- add a sticky navigation header with animated brand treatment and responsive link layout
- refresh the homepage hero, principle highlights, featured work, and social links with new copy, layouts, and calls to action

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902ae80cfc8832bbd701fea0a0a1f2a