### PR TITLE
Refresh homepage aesthetic with animated tech accents

### DIFF
--- a/content/index.njk
+++ b/content/index.njk
@@ -2,43 +2,64 @@
 layout: base.njk
 title: Dave Hulbert - Engineer
 ---
-<main class="px-6 py-16 sm:px-10">
+<main class="relative px-6 py-20 sm:px-10">
   <div class="mx-auto max-w-5xl space-y-16">
-    <section class="flex flex-col gap-10 lg:flex-row lg:items-center">
-      <div class="flex flex-col items-center text-center lg:w-64 lg:items-start lg:text-left">
+    <section class="glow-panel flex flex-col gap-12 p-8 sm:p-10 lg:flex-row lg:items-center">
+      <div class="absolute inset-x-0 top-0 hidden h-px w-full bg-gradient-to-r from-transparent via-sky-400/60 to-transparent lg:block"></div>
+      <div class="flex flex-col items-center gap-6 text-center lg:w-64 lg:items-start lg:text-left">
+        <div class="signal-chip">
+          <span class="relative flex h-2 w-2 items-center justify-center">
+            <span class="absolute inline-flex h-3 w-3 animate-ping rounded-full bg-emerald-300/70"></span>
+            <span class="relative inline-flex h-2 w-2 rounded-full bg-emerald-300"></span>
+          </span>
+          BUILD MODE
+        </div>
         <img
-          class="h-40 w-40 rounded-full border border-slate-800 shadow-2xl"
+          class="h-40 w-40 rounded-full border border-slate-700/80 shadow-[0_30px_80px_-50px_rgba(56,189,248,0.9)]"
           src="https://avatars.githubusercontent.com/u/50682?v=4"
           alt="Dave Hulbert's Avatar"
         >
-        <div class="mt-6 space-y-2">
+        <div class="space-y-3">
           <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl">Dave Hulbert</h1>
-          <p class="text-lg text-slate-300">Engineering leader • AI, Strategy and Compliance</p>
+          <p class="text-lg text-slate-300">Engineering leader • AI, strategy &amp; compliance</p>
+        </div>
+        <div class="flex flex-wrap justify-center gap-3 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-400/90 lg:justify-start">
+          <span class="rounded-full border border-slate-700/80 px-4 py-1 backdrop-sheen">AI Systems</span>
+          <span class="rounded-full border border-slate-700/80 px-4 py-1 backdrop-sheen">Platform Ops</span>
+          <span class="rounded-full border border-slate-700/80 px-4 py-1 backdrop-sheen">Team Design</span>
         </div>
       </div>
 
-      <div class="flex-1 space-y-5 text-lg text-slate-300">
-        <p>
-          I design systems and lead teams that deliver software that's trusted by millions.
-          My work spans engineering leadership, AI, strategy, software development and governance.
+      <div class="relative flex-1 space-y-6 text-lg text-slate-300">
+        <div class="pointer-events-none absolute -top-20 right-0 hidden h-32 w-32 rounded-full bg-sky-500/20 blur-3xl sm:block"></div>
+        <p class="relative leading-relaxed">
+          I design systems and lead teams that deliver software trusted by millions. My work spans engineering
+          leadership, AI strategy, software development and governance.
         </p>
-        <p>
+        <p class="relative leading-relaxed">
           I'm currently shaping the future of public transport technology at
-          <a class="text-sky-400 hover:text-sky-300" href="https://passenger.tech/" target="_blank" rel="noopener">Passenger</a>
-          in Bournemouth, UK. Outside of work I'm fascinated by the intersection of human systems,
-          automation, and the craft of well-run teams.
+          <a class="font-semibold text-sky-300 transition hover:text-sky-200" href="https://passenger.tech/" target="_blank" rel="noopener">Passenger</a>
+          in Bournemouth, UK. Outside of work I'm fascinated by the intersection of human systems, automation,
+          and the craft of well-run teams.
         </p>
-        <p>
-          Whether you're exploring responsible AI adoption, scaling engineering organisations, or simply
-          looking for pragmatic advice, I'd love to connect.
+        <p class="relative leading-relaxed">
+          Whether you're exploring responsible AI adoption, scaling engineering organisations, or looking for pragmatic
+          advice, I'd love to connect.
         </p>
-        <div>
+        <div class="relative flex flex-wrap gap-4">
           <a
-            class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
+            class="inline-flex items-center gap-2 rounded-full border border-sky-500/60 bg-sky-500/10 px-5 py-2 text-sm font-semibold text-sky-100 shadow-[0_0_35px_rgba(56,189,248,0.35)] transition duration-300 hover:-translate-y-0.5 hover:bg-sky-500/20"
             href="/blog/"
           >
             Visit the blog
             <span aria-hidden="true">→</span>
+          </a>
+          <a
+            class="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/60 px-5 py-2 text-sm font-semibold text-slate-200 transition duration-300 hover:-translate-y-0.5 hover:border-sky-500/60 hover:text-sky-200"
+            href="/work/"
+          >
+            Browse work
+            <span aria-hidden="true">↗</span>
           </a>
         </div>
       </div>
@@ -65,25 +86,26 @@ title: Dave Hulbert - Engineer
       <div class="grid gap-6 sm:grid-cols-2">
         {% for item in collections.workItems %}
           {% if item.data.featured %}
-        <article class="flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
-          <div class="space-y-3">
+        <article class="group relative flex h-full flex-col justify-between gap-5 overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_35px_90px_-60px_rgba(14,165,233,0.55)] transition duration-500 hover:-translate-y-1 hover:border-sky-500/60">
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-sky-500/0 via-sky-500/0 to-fuchsia-500/0 transition duration-500 group-hover:from-sky-500/10 group-hover:via-sky-500/5 group-hover:to-fuchsia-500/10"></div>
+          <div class="relative space-y-3">
             <h3 class="text-xl font-semibold text-slate-100">
-              <a class="transition hover:text-sky-300" href="{{ item.url }}">{{ item.data.title }}</a>
+              <a class="transition duration-300 hover:text-sky-300" href="{{ item.url }}">{{ item.data.title }}</a>
             </h3>
             {% if item.data.description %}
             <p class="text-sm text-slate-300">{{ item.data.description }}</p>
             {% endif %}
           </div>
-          <div class="flex flex-wrap gap-3 text-sm">
+          <div class="relative z-10 flex flex-wrap gap-3 text-sm">
             <a
-              class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+              class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold text-slate-200 transition duration-300 hover:-translate-y-0.5 hover:border-sky-500 hover:text-sky-200"
               href="{{ item.url }}"
             >
               Learn more
             </a>
             {% if item.data.websiteUrl %}
             <a
-              class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10"
+              class="inline-flex items-center gap-2 rounded-full border border-sky-500/70 px-3 py-1 font-semibold text-sky-200 transition duration-300 hover:-translate-y-0.5 hover:bg-sky-500/10"
               href="{{ item.data.websiteUrl }}"
               target="_blank"
               rel="noopener"
@@ -94,7 +116,7 @@ title: Dave Hulbert - Engineer
             {% endif %}
             {% if item.data.githubUrl %}
             <a
-              class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+              class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold text-slate-200 transition duration-300 hover:-translate-y-0.5 hover:border-sky-500 hover:text-sky-200"
               href="{{ item.data.githubUrl }}"
               target="_blank"
               rel="noopener"
@@ -118,8 +140,9 @@ title: Dave Hulbert - Engineer
           href="https://github.com/dave1010"
           target="_blank"
           rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
+          class="group relative flex items-start gap-4 overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 transition duration-500 hover:-translate-y-1 hover:border-sky-500/60 hover:bg-slate-900/60"
         >
+          <span class="pointer-events-none absolute inset-0 bg-gradient-to-r from-sky-500/0 via-sky-500/5 to-transparent opacity-0 transition duration-500 group-hover:opacity-100"></span>
           <img src="/img/Github_black.png" alt="GitHub Icon" width="40" height="40" class="shrink-0">
           <div>
             <h3 class="text-xl font-semibold text-slate-100">GitHub</h3>
@@ -131,8 +154,9 @@ title: Dave Hulbert - Engineer
           href="https://www.linkedin.com/in/dave1010/"
           target="_blank"
           rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
+          class="group relative flex items-start gap-4 overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 transition duration-500 hover:-translate-y-1 hover:border-sky-500/60 hover:bg-slate-900/60"
         >
+          <span class="pointer-events-none absolute inset-0 bg-gradient-to-r from-fuchsia-500/0 via-fuchsia-500/5 to-transparent opacity-0 transition duration-500 group-hover:opacity-100"></span>
           <img src="/img/LinkedIN_black.png" alt="LinkedIn Icon" width="40" height="40" class="shrink-0">
           <div>
             <h3 class="text-xl font-semibold text-slate-100">LinkedIn</h3>
@@ -144,8 +168,9 @@ title: Dave Hulbert - Engineer
           href="https://twitter.com/dave1010"
           target="_blank"
           rel="noopener"
-          class="group flex items-start gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-6 transition hover:border-sky-500 hover:bg-slate-900"
+          class="group relative flex items-start gap-4 overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 transition duration-500 hover:-translate-y-1 hover:border-sky-500/60 hover:bg-slate-900/60"
         >
+          <span class="pointer-events-none absolute inset-0 bg-gradient-to-r from-sky-500/0 via-sky-500/5 to-transparent opacity-0 transition duration-500 group-hover:opacity-100"></span>
           <img src="/img/Twitter_black.png" alt="Twitter Icon" width="40" height="40" class="shrink-0">
           <div>
             <h3 class="text-xl font-semibold text-slate-100">Twitter</h3>

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -11,8 +11,14 @@
     {{ headExtra | safe }}
   {% endif %}
 </head>
-<body class="h-full bg-slate-950 text-slate-100 font-sans antialiased">
-  <div class="min-h-screen flex flex-col">
+<body class="relative h-full min-h-screen overflow-x-hidden bg-slate-950 text-slate-100 font-sans antialiased">
+  <div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.18),transparent_60%),radial-gradient(circle_at_bottom,rgba(15,118,110,0.25),transparent_55%)]"></div>
+    <div class="tech-grid absolute inset-0 opacity-[0.18] mix-blend-lighten"></div>
+    <div class="absolute left-1/2 top-24 h-96 w-96 -ml-48 rounded-full bg-sky-500/25 blur-3xl animate-orbit"></div>
+    <div class="absolute -left-20 bottom-[-8rem] h-[28rem] w-[28rem] rounded-full bg-fuchsia-500/20 blur-[120px] animate-orbit-slower"></div>
+  </div>
+  <div class="relative z-10 flex min-h-screen flex-col">
     <main class="flex-1">
       {{ content | safe }}
     </main>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -9,3 +9,105 @@
     @apply selection:bg-sky-500/30 selection:text-slate-100;
   }
 }
+
+@layer components {
+  .tech-grid {
+    background-image: linear-gradient(to right, rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+    background-size: 80px 80px;
+  }
+
+  .glow-panel {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1.75rem;
+    border: 1px solid rgba(51, 65, 85, 0.55);
+    background: rgba(2, 6, 23, 0.78);
+    box-shadow: 0 45px 120px -60px rgba(56, 189, 248, 0.45);
+    backdrop-filter: blur(18px);
+    transition: transform 0.6s ease, border-color 0.6s ease, box-shadow 0.6s ease;
+  }
+
+  .glow-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.35), transparent 55%),
+      radial-gradient(circle at bottom left, rgba(244, 114, 182, 0.25), transparent 50%);
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+    pointer-events: none;
+  }
+
+  .glow-panel:hover {
+    transform: translateY(-4px) scale(1.01);
+    border-color: rgba(14, 165, 233, 0.55);
+    box-shadow: 0 50px 120px -50px rgba(14, 165, 233, 0.45);
+  }
+
+  .glow-panel:hover::before {
+    opacity: 0.8;
+    transform: scale(1.03);
+  }
+
+  .signal-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(56, 189, 248, 0.35);
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.16), rgba(14, 116, 144, 0.12));
+    font-size: 0.7rem;
+    letter-spacing: 0.36em;
+    text-transform: uppercase;
+    color: rgb(165 243 252);
+  }
+}
+
+@layer utilities {
+  .animate-orbit {
+    animation: orbitPulse 22s ease-in-out infinite;
+  }
+
+  .animate-orbit-slower {
+    animation: orbitPulse 34s ease-in-out infinite;
+  }
+
+  .backdrop-sheen {
+    position: relative;
+  }
+
+  .backdrop-sheen::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(130deg, transparent, rgba(56, 189, 248, 0.1), transparent);
+    opacity: 0;
+    transition: opacity 0.6s ease;
+  }
+
+  .backdrop-sheen:hover::after {
+    opacity: 1;
+  }
+}
+
+@keyframes orbitPulse {
+  0% {
+    opacity: 0.55;
+    transform: scale(0.9);
+  }
+
+  45% {
+    opacity: 0.95;
+    transform: scale(1.05);
+  }
+
+  100% {
+    opacity: 0.55;
+    transform: scale(0.9);
+  }
+}


### PR DESCRIPTION
## Summary
- wrap the base layout with animated gradient backdrops and a subtle grid to energize the dark theme
- introduce a hero "glow" panel, badges, and upgraded cards so the homepage feels more engineered and premium
- add bespoke Tailwind component and utility layers for glow panels, signal chips, and ambient orbit animations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6902ae80cfc8832bbd701fea0a0a1f2a