### PR TITLE
Format Tailwind styles for Biome compliance

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -11,7 +11,8 @@
 
   body {
     @apply min-h-screen bg-slate-950 font-sans text-slate-100 antialiased selection:bg-sky-500/30 selection:text-slate-100;
-    background-image: radial-gradient(circle at 20% 20%, rgba(125, 90, 240, 0.15), rgba(14, 23, 42, 0.1) 45%),
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(125, 90, 240, 0.15), rgba(14, 23, 42, 0.1) 45%),
       radial-gradient(circle at 80% 10%, rgba(19, 194, 194, 0.25), rgba(6, 11, 19, 0.05) 50%),
       radial-gradient(circle at 50% 90%, rgba(148, 240, 90, 0.14), rgba(15, 23, 42, 0.1) 55%),
       linear-gradient(180deg, rgba(10, 10, 20, 0.95), rgba(5, 9, 18, 0.92));
@@ -36,7 +37,13 @@
     content: "";
     position: absolute;
     inset: -40% -20%;
-    background: conic-gradient(from 90deg, rgba(125, 90, 240, 0.35), rgba(19, 194, 194, 0.25), rgba(25, 255, 182, 0.2), rgba(125, 90, 240, 0.35));
+    background: conic-gradient(
+      from 90deg,
+      rgba(125, 90, 240, 0.35),
+      rgba(19, 194, 194, 0.25),
+      rgba(25, 255, 182, 0.2),
+      rgba(125, 90, 240, 0.35)
+    );
     opacity: 0.35;
     filter: blur(60px);
     transform: rotate(15deg);
@@ -54,17 +61,17 @@
 
   .terminal-panel {
     @apply relative overflow-hidden rounded-3xl border border-lime-400/40 bg-slate-950/80 font-mono text-lime-200 shadow-glow;
-    box-shadow: inset 0 0 40px rgba(56, 189, 248, 0.1), 0 0 80px rgba(125, 90, 240, 0.25);
+    box-shadow:
+      inset 0 0 40px rgba(56, 189, 248, 0.1),
+      0 0 80px rgba(125, 90, 240, 0.25);
   }
 
   .terminal-panel::after {
     content: "";
     position: absolute;
     inset: 0;
-    background-image: linear-gradient(
-        rgba(148, 240, 90, 0.03) 1px,
-        transparent 1px
-      ),
+    background-image:
+      linear-gradient(rgba(148, 240, 90, 0.03) 1px, transparent 1px),
       linear-gradient(90deg, rgba(148, 240, 90, 0.03) 1px, transparent 1px);
     background-size: 0.75rem 0.75rem;
     mix-blend-mode: screen;
@@ -115,7 +122,8 @@
   .grid-overlay {
     position: absolute;
     inset: -50% -50%;
-    background-image: linear-gradient(rgba(125, 90, 240, 0.2) 1px, transparent 1px),
+    background-image:
+      linear-gradient(rgba(125, 90, 240, 0.2) 1px, transparent 1px),
       linear-gradient(90deg, rgba(19, 194, 194, 0.2) 1px, transparent 1px);
     background-size: 90px 90px;
     opacity: 0.15;
@@ -166,5 +174,4 @@
     background-size: 8px 8px;
     opacity: 0.5;
   }
-
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -36,12 +36,14 @@ module.exports = {
         glow: "0 0 30px rgba(125, 90, 240, 0.35)",
       },
       backgroundImage: {
-        "grid-glow": "linear-gradient(115deg, rgba(125,90,240,0.22) 0%, rgba(19,194,194,0.12) 35%, rgba(25,255,182,0.08) 100%)",
-        "hero-radial": "radial-gradient(circle at top, rgba(125, 90, 240, 0.3), rgba(9, 9, 17, 0.9))",
+        "grid-glow":
+          "linear-gradient(115deg, rgba(125,90,240,0.22) 0%, rgba(19,194,194,0.12) 35%, rgba(25,255,182,0.08) 100%)",
+        "hero-radial":
+          "radial-gradient(circle at top, rgba(125, 90, 240, 0.3), rgba(9, 9, 17, 0.9))",
       },
       animation: {
         "pulse-slow": "pulseSlow 6s ease-in-out infinite",
-        "float": "float 12s ease-in-out infinite",
+        float: "float 12s ease-in-out infinite",
         "grid-shift": "gridShift 18s linear infinite",
       },
       keyframes: {


### PR DESCRIPTION
## Summary
- reflow Tailwind CSS gradient declarations to match Biome's multiline style
- update Tailwind configuration gradients and animation keys to satisfy formatter

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_6903675ff220832bb6822d2cec7dd1ec