### PR TITLE
Prepend terminal system prompt with current date

### DIFF
--- a/functions/terminal-chat.ts
+++ b/functions/terminal-chat.ts
@@ -95,8 +95,11 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     return json({ error: "At least one user message is required" }, 400);
   }
 
+  const today = new Date().toISOString().slice(0, 10);
+  const systemPrompt = `The current date is ${today}. ${TERMINAL_SYSTEM_PROMPT}`;
+
   const outgoingMessages: ChatMessage[] = [
-    { role: "system", content: TERMINAL_SYSTEM_PROMPT },
+    { role: "system", content: systemPrompt },
     ...recentMessages,
   ];
 


### PR DESCRIPTION
## Summary
- prepend the terminal chat system prompt with a dynamically generated ISO-formatted current date so each request includes temporal context

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903bb5c84a8832b9dc0d7391f0c6a97