### PR TITLE
Update base layout to reference new favicon assets

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -11,7 +11,11 @@
     rel="stylesheet"
   >
   <link rel="stylesheet" href="/style.css">
-  <link rel="icon" href="https://avatars.githubusercontent.com/u/50682?v=4">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="alternate icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+  <link rel="manifest" href="/site.webmanifest">
   <link rel="alternate" type="application/rss+xml" title="Dave Hulbert - Blog" href="/feed.xml">
   {% if headExtra %}
     {{ headExtra | safe }}


### PR DESCRIPTION
## Summary
- replace the external GitHub avatar favicon reference with the new public favicon assets
- add links for the apple touch icon and site manifest so browsers pick up the updated branding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907c1541b80832ba7ae025cd4c8bc41