### PR TITLE
Redesign site with a calmer editorial visual system

### DIFF
--- a/content/work/index.njk
+++ b/content/work/index.njk
@@ -12,19 +12,16 @@ title: Work - Dave Hulbert
     {% set otherItems = otherItems.concat([item]) %}
   {% endif %}
 {% endfor %}
-<main class="px-6 py-16 sm:px-10">
+<main class="px-6 py-14 sm:px-10">
   <div class="mx-auto flex max-w-5xl flex-col gap-16">
     <header class="space-y-6 text-center sm:text-left">
-      <a
-        class="mx-auto inline-flex items-center gap-2 text-sm font-medium text-sky-400 transition hover:text-sky-300 sm:mx-0"
-        href="/"
-      >
+      <a class="mx-auto inline-flex items-center gap-2 text-sm font-medium text-stone-600 transition hover:text-stone-900 sm:mx-0" href="/">
         <span aria-hidden="true">←</span>
         Back to home
       </a>
       <div class="space-y-4">
-        <h1 class="text-4xl font-semibold tracking-tight text-slate-100">Selected work</h1>
-        <p class="text-lg text-slate-300">
+        <h1 class="text-4xl font-semibold tracking-tight text-stone-900">Selected work</h1>
+        <p class="text-lg text-stone-700">
           A collection of experiments, products, and collaborations. Featured projects showcase the tools I'm most
           excited about right now, with more explorations listed below.
         </p>
@@ -33,7 +30,7 @@ title: Work - Dave Hulbert
 
     {% if featuredItems | length %}
     <section class="space-y-6">
-      <h2 class="text-2xl font-semibold tracking-tight text-slate-100">Featured</h2>
+      <h2 class="text-2xl font-semibold tracking-tight text-stone-900">Featured</h2>
       <div class="grid gap-6 sm:grid-cols-2">
         {% for item in featuredItems %}
           {{ renderWorkCard(item, {
@@ -41,9 +38,9 @@ title: Work - Dave Hulbert
             primaryLabel: "Learn more",
             websiteLabel: "Visit site",
             githubLabel: "View source",
-            articleClasses: "flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40",
-            titleClasses: "text-xl font-semibold text-slate-100",
-            titleLinkClasses: "transition hover:text-sky-300",
+            articleClasses: "shell-card flex h-full flex-col justify-between gap-4 p-6",
+            titleClasses: "text-xl font-semibold text-stone-900",
+            titleLinkClasses: "transition hover:text-stone-600",
             ctaContainerClasses: "flex flex-wrap gap-3 text-sm"
           }) | safe }}
         {% endfor %}
@@ -53,7 +50,7 @@ title: Work - Dave Hulbert
 
     {% if otherItems | length %}
     <section class="space-y-6">
-      <h2 class="text-2xl font-semibold tracking-tight text-slate-100">More work</h2>
+      <h2 class="text-2xl font-semibold tracking-tight text-stone-900">More work</h2>
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {% for item in otherItems %}
           {{ renderWorkCard(item, {

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full bg-slate-950">
+<html lang="en" class="h-full bg-stone-100">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,650&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
     rel="stylesheet"
   >
   <link rel="stylesheet" href="/style.css">
@@ -21,33 +21,21 @@
     {{ headExtra | safe }}
   {% endif %}
 </head>
-<body class="relative min-h-screen overflow-x-hidden">
+<body class="relative min-h-screen overflow-x-hidden bg-stone-100 text-stone-800">
   <div aria-hidden="true" class="pointer-events-none fixed inset-0 overflow-hidden">
-    <div class="grid-overlay"></div>
-    <div class="absolute -left-40 top-1/4 h-96 w-96 rounded-full bg-sky-400/20 blur-3xl"></div>
-    <div class="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-fuchsia-500/20 blur-3xl"></div>
-    <svg class="absolute -top-20 right-0 h-[540px] w-[540px] opacity-40" viewBox="0 0 400 400" fill="none">
-      <defs>
-        <linearGradient id="diagonalGradient" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0%" stop-color="#7D5AF0" stop-opacity="0.6" />
-          <stop offset="50%" stop-color="#13C2C2" stop-opacity="0.3" />
-          <stop offset="100%" stop-color="#19FFB6" stop-opacity="0.2" />
-        </linearGradient>
-      </defs>
-      <path d="M0 140 L400 0 L400 260 L0 400 Z" fill="url(#diagonalGradient)" />
-      <path d="M-40 120 L400 -20" stroke="#13C2C2" stroke-width="2" stroke-opacity="0.4" stroke-dasharray="10 14" />
-      <path d="M-60 220 L420 60" stroke="#7D5AF0" stroke-width="1.5" stroke-opacity="0.5" stroke-dasharray="6 12" />
-    </svg>
+    <div class="paper-grid"></div>
+    <div class="absolute -left-32 top-12 h-72 w-72 rounded-full bg-amber-300/20 blur-3xl"></div>
+    <div class="absolute -right-20 bottom-8 h-80 w-80 rounded-full bg-rose-300/20 blur-3xl"></div>
   </div>
   <div class="relative z-10 flex min-h-screen flex-col">
     <header class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pb-8 pt-10 sm:flex-row sm:items-center sm:justify-between sm:px-10">
-      <a href="/" class="text-sm font-semibold uppercase tracking-[0.35em] text-slate-200 transition hover:text-lime-300">
+      <a href="/" class="text-sm font-semibold uppercase tracking-[0.35em] text-stone-700 transition hover:text-stone-900">
         dave.engineer
       </a>
       {% if navigation and navigation | length %}
-      <nav class="flex flex-wrap items-center gap-6 text-sm font-medium text-slate-200/90">
+      <nav class="flex flex-wrap items-center gap-6 text-sm font-medium text-stone-700/90">
         {% for link in navigation %}
-        <a class="hover:text-lime-300" href="{{ link.href }}">{{ link.label }}</a>
+        <a class="hover:text-stone-950" href="{{ link.href }}">{{ link.label }}</a>
         {% endfor %}
       </nav>
       {% endif %}
@@ -55,17 +43,17 @@
     <main class="flex-1">
       {{ content | safe }}
     </main>
-    <footer class="border-t border-slate-800/40 bg-slate-950/80">
-      <div class="mx-auto flex max-w-6xl flex-col gap-5 px-6 py-10 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-10">
-        <nav class="flex flex-wrap items-center gap-5 text-sm font-medium text-slate-300">
-          <a class="hover:text-lime-300" href="/">dave.engineer</a>
+    <footer class="border-t border-stone-300/80 bg-stone-100/95">
+      <div class="mx-auto flex max-w-6xl flex-col gap-5 px-6 py-10 text-sm text-stone-600 sm:flex-row sm:items-center sm:justify-between sm:px-10">
+        <nav class="flex flex-wrap items-center gap-5 text-sm font-medium text-stone-700">
+          <a class="hover:text-stone-900" href="/">dave.engineer</a>
           {% if navigation and navigation | length %}
             {% for link in navigation %}
-            <a class="hover:text-lime-300" href="{{ link.href }}">{{ link.label }}</a>
+            <a class="hover:text-stone-900" href="{{ link.href }}">{{ link.label }}</a>
             {% endfor %}
           {% endif %}
         </nav>
-        <p class="text-xs text-slate-500">© Dave Hulbert</p>
+        <p class="text-xs text-stone-500">© Dave Hulbert</p>
       </div>
     </footer>
   </div>

--- a/src/layouts/blog-list.njk
+++ b/src/layouts/blog-list.njk
@@ -14,39 +14,39 @@ layout: base.njk
 {% endfor %}
 {% set tagList = collections.blogTags | default([]) %}
 {% set tagLinkClasses = tagClasses() %}
-{% set tagCountClasses = "rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] font-medium text-slate-400" %}
-{% set paginationButtonClasses = "inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1 text-sm font-medium text-slate-300 transition hover:border-slate-600 hover:text-slate-100" %}
-{% set paginationActiveClasses = "border-sky-500/80 text-sky-200" %}
-<main class="px-6 py-16 sm:px-10">
+{% set tagCountClasses = "rounded-full border border-stone-300 bg-stone-100 px-2 py-0.5 text-[0.65rem] font-medium text-stone-500" %}
+{% set paginationButtonClasses = "inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700 transition hover:border-stone-500 hover:text-stone-900" %}
+{% set paginationActiveClasses = "border-stone-600 text-stone-900" %}
+<main class="px-6 py-14 sm:px-10">
   <div class="mx-auto flex max-w-4xl flex-col gap-12">
     <header class="space-y-4">
       <a
-        class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
+        class="inline-flex items-center gap-2 text-sm font-medium text-stone-600 hover:text-stone-900"
         href="/"
       >
         <span aria-hidden="true">←</span>
         Back to home
       </a>
-      <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-400">Archive</p>
-      <h1 class="text-4xl font-semibold tracking-tight text-slate-100">{{ listTitle or "Writing" }}</h1>
+      <p class="text-sm font-medium uppercase tracking-[0.2em] text-stone-500">Archive</p>
+      <h1 class="text-4xl font-semibold tracking-tight text-stone-900">{{ listTitle or "Writing" }}</h1>
       {% if listDescription %}
-        <p class="text-lg text-slate-300">{{ listDescription }}</p>
+        <p class="text-lg text-stone-700">{{ listDescription }}</p>
       {% endif %}
     </header>
 
     {% if typeGroups | length %}
     <nav aria-label="Filter posts by type" class="flex flex-col gap-3">
-      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Filter by type</p>
+      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">Filter by type</p>
       <ul class="flex flex-wrap gap-2">
         <li>
           {% set isAllActive = not currentType %}
           <a
             href="/blog/"
-            class="inline-flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-slate-700 hover:text-slate-100 {{ "border-sky-500/80 text-sky-200" if isAllActive }}"
+            class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-stone-500 hover:text-stone-900 {{ "border-stone-600 text-stone-900" if isAllActive }}"
             {% if isAllActive %}aria-current="page"{% endif %}
           >
             All
-            <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] font-medium text-slate-400">{{ totalCount }}</span>
+            <span class="rounded-full border border-stone-300 bg-stone-100 px-2 py-0.5 text-[0.65rem] font-medium text-stone-500">{{ totalCount }}</span>
           </a>
         </li>
         {% for group in typeGroups %}
@@ -54,19 +54,19 @@ layout: base.njk
           {% set isActive = currentType == group.type %}
           {% set badgeClasses = "" %}
           {% if group.type == "post" %}
-            {% set badgeClasses = "border-sky-500/80 text-sky-200" %}
+            {% set badgeClasses = "border-stone-600 text-stone-900" %}
           {% elseif group.type == "til" %}
-            {% set badgeClasses = "border-lime-500/80 text-lime-200" %}
+            {% set badgeClasses = "border-emerald-400 text-emerald-800" %}
           {% elseif group.type == "external" %}
-            {% set badgeClasses = "border-amber-500/80 text-amber-200" %}
+            {% set badgeClasses = "border-amber-400 text-amber-800" %}
           {% endif %}
           <a
             href="{{ group.permalink }}"
-            class="inline-flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-slate-700 hover:text-slate-100 {{ badgeClasses if isActive }}"
+            class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-stone-500 hover:text-stone-900 {{ badgeClasses if isActive }}"
             {% if isActive %}aria-current="page"{% endif %}
           >
             {{ group.label }}
-            <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] font-medium text-slate-400">{{ group.count }}</span>
+            <span class="rounded-full border border-stone-300 bg-stone-100 px-2 py-0.5 text-[0.65rem] font-medium text-stone-500">{{ group.count }}</span>
           </a>
         </li>
         {% endfor %}
@@ -78,15 +78,15 @@ layout: base.njk
     {% set tagPreview = tagList.slice(0, 12) %}
     <section class="space-y-3">
       <div class="flex items-center justify-between gap-4">
-        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Browse by tag</p>
-        <a class="text-xs font-semibold tracking-wide text-sky-300 transition hover:text-sky-200" href="/blog/tag/">View all tags →</a>
+        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">Browse by tag</p>
+        <a class="text-xs font-semibold tracking-wide text-stone-600 transition hover:text-stone-900" href="/blog/tag/">View all tags →</a>
       </div>
       <div class="{{ tagContainerClasses() }}">
         {% for tag in tagPreview %}
         {% set isCurrentTag = currentTagSlug and currentTagSlug == tag.slug %}
         <a
           href="{{ tag.permalink }}"
-          class="{{ tagLinkClasses }} {{ "border-sky-500/80 text-sky-200" if isCurrentTag }}"
+          class="{{ tagLinkClasses }} {{ "border-stone-600 text-stone-900" if isCurrentTag }}"
           {% if isCurrentTag %}aria-current="page"{% endif %}
         >
           {{ tag.name | lower }}
@@ -98,7 +98,7 @@ layout: base.njk
     {% endif %}
 
     {% if content | trim %}
-      <div class="prose prose-invert max-w-none">{{ content | safe }}</div>
+      <div class="prose max-w-none">{{ content | safe }}</div>
     {% endif %}
 
     {{ renderPostList(postsToRender, {
@@ -109,7 +109,7 @@ layout: base.njk
 
     {% if listingPagination and listingPagination.totalPages > 1 %}
     <nav aria-label="Pagination" class="flex flex-col items-center gap-3 pt-6">
-      <p class="text-sm text-slate-400">Page {{ listingPagination.currentPage }} of {{ listingPagination.totalPages }}</p>
+      <p class="text-sm text-stone-500">Page {{ listingPagination.currentPage }} of {{ listingPagination.totalPages }}</p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         {% if listingPagination.previous %}
         <a class="{{ paginationButtonClasses }}" href="{{ listingPagination.previous.url }}">

--- a/src/layouts/components/blog-meta.njk
+++ b/src/layouts/components/blog-meta.njk
@@ -1,5 +1,5 @@
 {% set DEFAULT_TAG_CONTAINER_CLASSES = "flex flex-wrap gap-2" %}
-{% set DEFAULT_TAG_CLASSES = "inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1 text-xs font-semibold tracking-wide text-slate-300 transition hover:border-slate-600 hover:text-slate-100" %}
+{% set DEFAULT_TAG_CLASSES = "inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-xs font-semibold tracking-wide text-stone-700 transition hover:border-stone-500 hover:text-stone-900" %}
 {% set DEFAULT_TYPE_BASE_CLASSES = "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide" %}
 
 {% macro tagContainerClasses(extra = "") %}
@@ -43,19 +43,18 @@
 
 {% macro renderPostHeader(title, isoDate, displayDate, topicTagLinks = [], topicTags = [], options = {}) %}
   {% set containerClasses = options.containerClasses or "space-y-5" %}
-  {% set headingClasses = options.headingClasses or "text-4xl font-semibold tracking-tight text-slate-100" %}
+  {% set headingClasses = options.headingClasses or "text-4xl font-semibold tracking-tight text-stone-900" %}
   {% set breadcrumbHref = options.breadcrumbHref or "/blog/" %}
   {% set breadcrumbLabel = options.breadcrumbLabel or "Blog" %}
   {% set showBreadcrumb = options.showBreadcrumb | default(true) %}
-  {% set dateClasses = options.dateClasses or "text-base text-slate-400" %}
-  {% set metadataRowClasses = options.metadataRowClasses or "flex flex-wrap items-center gap-3 text-sm text-slate-400" %}
+  {% set metadataRowClasses = options.metadataRowClasses or "flex flex-wrap items-center gap-3 text-sm text-stone-500" %}
   {% set typeOptions = options.typeOptions or {} %}
   {% set typeValue = options.type or options.postType %}
   {% set typeLabel = options.typeLabel or options.postTypeLabel %}
   {% set showType = options.showTypeBadge | default(typeValue or typeLabel) %}
   <header class="{{ containerClasses }}">
     {% if showBreadcrumb %}
-    <a class="text-sm font-medium uppercase tracking-wide text-slate-400 hover:text-slate-200" href="{{ breadcrumbHref }}">{{ breadcrumbLabel }}</a>
+    <a class="text-sm font-medium uppercase tracking-wide text-stone-500 hover:text-stone-900" href="{{ breadcrumbHref }}">{{ breadcrumbLabel }}</a>
     {% endif %}
     <h1 class="{{ headingClasses }}">{{ title }}</h1>
     {% if displayDate or showType %}
@@ -80,9 +79,9 @@
   {% set baseClasses = options.baseClasses or DEFAULT_TYPE_BASE_CLASSES %}
   {% set extraClasses = options.extraClasses or "" %}
   {% set variants = {
-    "post": "border-sky-400/40 bg-sky-500/10 text-sky-200",
-    "til": "border-lime-400/40 bg-lime-400/10 text-lime-100",
-    "external": "border-amber-400/40 bg-amber-400/10 text-amber-100"
+    "post": "border-stone-300 bg-stone-100 text-stone-700",
+    "til": "border-emerald-300 bg-emerald-50 text-emerald-800",
+    "external": "border-amber-300 bg-amber-50 text-amber-800"
   } %}
   {% set typeKey = (type | default('post')) | lower %}
   {% set labelMap = {
@@ -96,7 +95,7 @@
 {% endmacro %}
 
 {% macro renderPostCta(url, label, options = {}) %}
-  {% set classes = options.classes or "inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300" %}
+  {% set classes = options.classes or "inline-flex items-center gap-2 text-sm font-semibold text-stone-700 hover:text-stone-950" %}
   {% set icon = options.icon or "→" %}
   {% set rel = options.rel %}
   {% set target = options.target %}

--- a/src/layouts/components/home/featured-work.njk
+++ b/src/layouts/components/home/featured-work.njk
@@ -8,23 +8,19 @@
     {% endif %}
   {% endfor %}
   {% if featuredItems | length %}
-  <section class="space-y-10">
+  <section class="space-y-8">
     <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
       <div class="space-y-2">
         {% if config.sectionLabel %}
-        <p class="text-xs uppercase tracking-[0.45em] text-slate-500">{{ config.sectionLabel }}</p>
+        <p class="text-xs uppercase tracking-[0.35em] text-stone-500">{{ config.sectionLabel }}</p>
         {% endif %}
         {% if config.sectionTitle %}
-        <h2 class="text-3xl font-semibold text-slate-100">{{ config.sectionTitle }}</h2>
+        <h2 class="text-3xl font-semibold text-stone-900">{{ config.sectionTitle }}</h2>
         {% endif %}
       </div>
       {% if config.viewAllHref and config.viewAllLabel %}
-      <a
-        class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-lime-300 hover:text-lime-200"
-        href="{{ config.viewAllHref }}"
-      >
-        {{ config.viewAllLabel }}
-        <span aria-hidden="true">→</span>
+      <a class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-stone-700 hover:border-stone-500 hover:text-stone-900" href="{{ config.viewAllHref }}">
+        {{ config.viewAllLabel }}<span aria-hidden="true">→</span>
       </a>
       {% endif %}
     </div>

--- a/src/layouts/components/home/hero.njk
+++ b/src/layouts/components/home/hero.njk
@@ -1,112 +1,80 @@
 {% macro renderHomeHero(hero) %}
-  <section class="relative overflow-hidden rounded-[2.75rem] border border-slate-800/60 bg-slate-950/70 p-4 pt-10 shadow-glow sm:p-16 sm:pt-14" data-parallax-root>
-    <div class="pointer-events-none absolute inset-0 opacity-50 parallax" data-parallax>
-      <svg class="absolute -top-32 left-1/2 h-[420px] -translate-x-1/2" viewBox="0 0 600 400" fill="none" data-parallax-depth="0.08">
-        <g stroke="rgba(125,90,240,0.4)" stroke-width="1">
-          <path d="M0 120 L580 0" />
-          <path d="M0 180 L580 60" />
-          <path d="M0 240 L580 120" />
-          <path d="M0 300 L580 180" />
-        </g>
-        <g stroke="rgba(25,255,182,0.25)" stroke-width="1" stroke-dasharray="12 16">
-          <path d="M40 400 L600 40" />
-          <path d="M120 420 L600 120" />
-        </g>
+  <section class="shell-card relative overflow-hidden p-6 sm:p-12" data-parallax-root>
+    <div class="pointer-events-none absolute inset-0 opacity-70 parallax" data-parallax>
+      <svg class="absolute -top-20 right-4 h-[340px] w-[460px] text-stone-400/40" viewBox="0 0 480 360" fill="none" data-parallax-depth="0.06">
+        <path d="M20 60H450M20 120H450M20 180H450M20 240H450M20 300H450" stroke="currentColor" stroke-width="1" />
+        <path d="M70 20V340M160 20V340M250 20V340M340 20V340M430 20V340" stroke="currentColor" stroke-width="1" />
       </svg>
-      <div class="absolute inset-0 -skew-y-3 bg-gradient-to-br from-slate-900/10 via-fuchsia-500/10 to-sky-500/10 mix-blend-screen" data-parallax-depth="0.05"></div>
-      <div class="absolute -bottom-24 left-12 h-44 w-44 rounded-full bg-sky-400/20 blur-3xl" data-parallax-depth="0.12"></div>
-      <div class="absolute -top-16 right-6 h-56 w-56 -skew-y-12 rounded-3xl border border-sky-300/40" data-parallax-depth="0.18"></div>
+      <div class="absolute -bottom-16 right-10 h-52 w-52 rounded-full bg-amber-300/25 blur-3xl" data-parallax-depth="0.14"></div>
     </div>
-    <div class="relative z-10 grid gap-16 lg:grid-cols-[minmax(0,1.15fr)_380px]">
-      <div class="space-y-10">
-        <div class="space-y-6">
-          {% if hero.badgeLabel %}
-          <p class="inline-flex items-center gap-3 rounded-full border border-lime-400/40 bg-slate-900/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-lime-300">
-            <span class="inline-flex h-2 w-2 rounded-full bg-lime-300 shadow-glow"></span>
-            {{ hero.badgeLabel }}
-          </p>
-          {% endif %}
-          <div class="flex flex-col gap-6 sm:flex-row sm:items-center">
-            <img
-              src="/img/dave.jpg"
-              alt="Dave Hulbert"
-              width="132"
-              height="132"
-              class="h-28 w-28 rounded-full border border-lime-300/40 bg-slate-900/60 object-cover shadow-glow"
-              loading="lazy"
-            >
-            <div class="space-y-4">
-              {% if hero.name %}
-              <h1 class="text-balance text-4xl font-semibold leading-tight tracking-tight text-slate-100 sm:text-5xl lg:text-6xl">
-                {{ hero.name }}
-              </h1>
-              {% endif %}
-              {% if hero.subtitle %}
-              <p class="text-lg font-medium uppercase tracking-[0.3em] text-slate-300">{{ hero.subtitle }}</p>
-              {% endif %}
-            </div>
+    <div class="relative z-10 grid gap-12 lg:grid-cols-[minmax(0,1.2fr)_360px]">
+      <div class="space-y-8">
+        {% if hero.badgeLabel %}
+        <p class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-stone-600">
+          <span class="inline-flex h-2 w-2 rounded-full bg-amber-500"></span>
+          {{ hero.badgeLabel }}
+        </p>
+        {% endif %}
+
+        <div class="flex flex-col gap-6 sm:flex-row sm:items-center">
+          <img
+            src="/img/dave.jpg"
+            alt="Dave Hulbert"
+            width="132"
+            height="132"
+            class="h-28 w-28 rounded-2xl border border-stone-300 bg-stone-200 object-cover"
+            loading="lazy"
+          >
+          <div class="space-y-3">
+            {% if hero.name %}
+            <h1 class="text-balance text-4xl font-semibold leading-tight text-stone-900 sm:text-5xl lg:text-6xl">{{ hero.name }}</h1>
+            {% endif %}
+            {% if hero.subtitle %}
+            <p class="text-sm font-semibold uppercase tracking-[0.28em] text-stone-600">{{ hero.subtitle }}</p>
+            {% endif %}
           </div>
         </div>
+
         {% if hero.paragraphs and hero.paragraphs | length %}
-        <div class="space-y-6 text-lg text-slate-300">
+        <div class="space-y-4 text-lg text-stone-700">
           {% for paragraph in hero.paragraphs %}
           <p>{{ paragraph }}</p>
           {% endfor %}
         </div>
         {% endif %}
+
         {% if hero.ctas and hero.ctas | length %}
-        <div class="flex flex-wrap items-center gap-5">
+        <div class="flex flex-wrap items-center gap-4">
           {% for cta in hero.ctas %}
-          <a
-            class="inline-flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.3em] text-sky-300 transition hover:text-lime-200"
-            href="{{ cta.href }}"
-          >
-            {{ cta.label }}
-            {% if cta.trailingIcon %}
-            <span aria-hidden="true" class="text-base">{{ cta.trailingIcon }}</span>
-            {% endif %}
+          <a class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-sm font-semibold text-stone-700 hover:border-stone-500 hover:text-stone-950" href="{{ cta.href }}">
+            {{ cta.label }}{% if cta.trailingIcon %}<span aria-hidden="true">{{ cta.trailingIcon }}</span>{% endif %}
           </a>
           {% endfor %}
         </div>
         {% endif %}
       </div>
-      <div class="relative flex flex-col items-center justify-between gap-6">
-        <div class="perspective-1200 relative h-[340px] w-full max-w-[420px]">
-          <div class="absolute inset-0 rounded-[2rem] border border-slate-800/60 bg-hero-radial"></div>
-          <canvas id="hero-orb" class="relative h-full w-full rounded-[2rem]"></canvas>
-          <div class="pointer-events-none absolute inset-0 rounded-[2rem] border border-fuchsia-500/20"></div>
+
+      <div class="flex flex-col gap-5">
+        <div class="relative h-[280px] w-full overflow-hidden rounded-[1.6rem] border border-stone-300 bg-stone-200/70">
+          <canvas id="hero-orb" class="relative h-full w-full"></canvas>
         </div>
-        <div class="terminal-panel w-full max-w-[420px]" data-terminal-root>
+        <div class="terminal-panel" data-terminal-root>
           <div class="terminal-header">
             <span class="terminal-dot terminal-dot--close" aria-hidden="true"></span>
             <span class="terminal-dot terminal-dot--minimize" aria-hidden="true"></span>
             <span class="terminal-dot terminal-dot--zoom" aria-hidden="true"></span>
-            <p class="ml-3 text-xs uppercase tracking-[0.4em] text-lime-200/80">Interactive Terminal</p>
+            <p class="ml-3 text-xs uppercase tracking-[0.35em] text-stone-300">Interactive terminal</p>
           </div>
           <div class="terminal-body" data-terminal>
             <div class="terminal-output" data-terminal-output>
-              <div class="terminal-line">
-                <span class="terminal-line__prompt">$</span>
-                <span class="terminal-line__command">ls</span>
-              </div>
+              <div class="terminal-line"><span class="terminal-line__prompt">$</span><span class="terminal-line__command">ls</span></div>
               <pre class="terminal-block">{{ "hello.txt\nindex.md" }}</pre>
             </div>
             <form class="terminal-form" data-terminal-form autocomplete="off">
               <label class="sr-only" for="terminal-input">Enter a command</label>
               <div class="terminal-input-row">
                 <span class="terminal-line__prompt">$</span>
-                <input
-                  id="terminal-input"
-                  class="terminal-input"
-                  type="text"
-                  data-terminal-input
-                  name="command"
-                  autocomplete="off"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  spellcheck="false"
-                  aria-label="Terminal input"
-                >
+                <input id="terminal-input" class="terminal-input" type="text" data-terminal-input name="command" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-label="Terminal input">
               </div>
             </form>
           </div>

--- a/src/layouts/components/home/recent-posts.njk
+++ b/src/layouts/components/home/recent-posts.njk
@@ -6,25 +6,21 @@
     <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
       <div class="space-y-2">
         {% if config.sectionLabel %}
-        <p class="text-xs uppercase tracking-[0.45em] text-slate-500">{{ config.sectionLabel }}</p>
+        <p class="text-xs uppercase tracking-[0.35em] text-stone-500">{{ config.sectionLabel }}</p>
         {% endif %}
         {% if config.sectionTitle %}
-        <h2 class="text-3xl font-semibold text-slate-100">{{ config.sectionTitle }}</h2>
+        <h2 class="text-3xl font-semibold text-stone-900">{{ config.sectionTitle }}</h2>
         {% endif %}
       </div>
       {% if config.viewAllHref and config.viewAllLabel %}
-      <a
-        class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-lime-300 hover:text-lime-200"
-        href="{{ config.viewAllHref }}"
-      >
-        {{ config.viewAllLabel }}
-        <span aria-hidden="true">→</span>
+      <a class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-stone-700 hover:border-stone-500 hover:text-stone-900" href="{{ config.viewAllHref }}">
+        {{ config.viewAllLabel }}<span aria-hidden="true">→</span>
       </a>
       {% endif %}
     </div>
     {{ renderPostList(posts, {
-      containerClasses: "flex flex-col divide-y divide-slate-800/80 overflow-hidden rounded-[2rem] border border-slate-800/60 bg-slate-950/40",
-      articleClasses: "group flex flex-col gap-3 px-6 py-6 transition hover:bg-slate-900/70 sm:px-8",
+      containerClasses: "shell-card flex flex-col divide-y divide-stone-200 overflow-hidden",
+      articleClasses: "group flex flex-col gap-3 px-6 py-6 transition hover:bg-stone-100/60 sm:px-8",
       headingLevel: "h3",
       truncateLength: 180
     }) | safe }}

--- a/src/layouts/components/home/social.njk
+++ b/src/layouts/components/home/social.njk
@@ -1,23 +1,17 @@
 {% macro renderSocialSection(config, links) %}
   {% if links and links | length %}
-  <section class="relative rounded-[2.75rem] border border-slate-800/60 bg-slate-950/70 p-4 shadow-glow sm:p-16">
-    <div class="absolute inset-0 dot-matrix rounded-[2.75rem] opacity-20"></div>
+  <section class="shell-card relative p-6 sm:p-12">
     <div class="relative z-10 space-y-6">
       {% if config.sectionLabel %}
-      <p class="text-xs uppercase tracking-[0.45em] text-slate-500">{{ config.sectionLabel }}</p>
+      <p class="text-xs uppercase tracking-[0.35em] text-stone-500">{{ config.sectionLabel }}</p>
       {% endif %}
       {% if config.sectionTitle %}
-      <h2 class="text-3xl font-semibold text-slate-100">{{ config.sectionTitle }}</h2>
+      <h2 class="text-3xl font-semibold text-stone-900">{{ config.sectionTitle }}</h2>
       {% endif %}
       <div class="grid gap-4 sm:grid-cols-2">
         {% for link in links %}
-        <a
-          href="{{ link.href }}"
-          target="_blank"
-          rel="noopener"
-          class="glow-card flex flex-col gap-2 border-slate-700/60"
-        >
-          <h3 class="text-lg font-semibold text-slate-100">{{ link.label }}</h3>
+        <a href="{{ link.href }}" target="_blank" rel="noopener" class="rounded-2xl border border-stone-300 bg-stone-100 px-5 py-4 text-lg font-semibold text-stone-800 hover:border-stone-500 hover:text-stone-950">
+          {{ link.label }}
         </a>
         {% endfor %}
       </div>

--- a/src/layouts/components/post-list.njk
+++ b/src/layouts/components/post-list.njk
@@ -1,15 +1,15 @@
 {% from "components/blog-meta.njk" import renderPostTypeBadge, renderTagList, renderPostCta, tagClasses, tagContainerClasses %}
 {% macro renderPostList(posts = [], options = {}) %}
   {% set items = posts | default([]) %}
-  {% set containerClasses = options.containerClasses or "flex flex-col divide-y divide-slate-800/80 border border-slate-800/60 bg-slate-900/40" %}
-  {% set articleClasses = options.articleClasses or "group flex flex-col gap-3 px-6 py-6 transition hover:bg-slate-900/70 sm:px-8" %}
+  {% set containerClasses = options.containerClasses or "flex flex-col divide-y divide-stone-200 border border-stone-300 bg-stone-50/80" %}
+  {% set articleClasses = options.articleClasses or "group flex flex-col gap-3 px-6 py-6 transition hover:bg-stone-100/70 sm:px-8" %}
   {% set headingLevel = options.headingLevel or "h2" %}
   {% set truncateLength = options.truncateLength or 220 %}
   {% set showEmptyMessage = options.showEmptyMessage | default(false) %}
   {% set emptyMessage = options.emptyMessage or "No posts found." %}
   {% set tagLinkClasses = options.tagLinkClasses or tagClasses() %}
   {% set tagListClasses = options.tagListClasses or tagContainerClasses() %}
-  {% set ctaClasses = options.ctaClasses or "mt-2 inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300" %}
+  {% set ctaClasses = options.ctaClasses or "mt-2 inline-flex items-center gap-2 text-sm font-semibold text-stone-700 hover:text-stone-950" %}
   <div class="{{ containerClasses }}">
     {% if items | length %}
       {% for post in items %}
@@ -42,7 +42,7 @@
           {% set ctaRel = "noopener noreferrer" %}
         {% endif %}
         <article class="{{ articleClasses }}">
-          <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400">
+          <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-stone-500">
             <div class="flex flex-wrap items-center gap-3">
               {{ renderPostTypeBadge(post.data.type, typeLabel) | safe }}
               <time datetime="{{ post.data.isoDate }}">{{ post.data.displayDate }}</time>
@@ -52,11 +52,11 @@
               tagClasses: tagLinkClasses
             }) | safe }}
           </div>
-          <{{ headingLevel }} class="text-2xl font-semibold tracking-tight text-slate-100">
-            <a class="block transition hover:text-sky-300" href="{{ post.url }}">{{ post.data.title }}</a>
+          <{{ headingLevel }} class="text-2xl font-semibold tracking-tight text-stone-900">
+            <a class="block transition hover:text-stone-600" href="{{ post.url }}">{{ post.data.title }}</a>
           </{{ headingLevel }}>
           {% if summary %}
-          <p class="text-base text-slate-300">{{ summary }}</p>
+          <p class="text-base text-stone-700">{{ summary }}</p>
           {% endif %}
           {{ renderPostCta(ctaUrl, ctaLabel, {
             classes: ctaClasses,
@@ -66,7 +66,7 @@
         </article>
       {% endfor %}
     {% elseif showEmptyMessage %}
-      <p class="px-6 py-10 text-center text-sm text-slate-400 sm:px-8">{{ emptyMessage }}</p>
+      <p class="px-6 py-10 text-center text-sm text-stone-500 sm:px-8">{{ emptyMessage }}</p>
     {% endif %}
   </div>
 {% endmacro %}

--- a/src/layouts/components/work-card.njk
+++ b/src/layouts/components/work-card.njk
@@ -1,25 +1,25 @@
 {% set WORK_CARD_VARIANTS = {
   "featured": {
-    articleClasses: "glow-card flex h-full flex-col justify-between gap-6 border-slate-800/80",
-    metaClasses: "text-xs uppercase tracking-[0.4em] text-slate-500",
-    titleClasses: "text-2xl font-semibold text-slate-100",
-    titleLinkClasses: "transition hover:text-lime-200",
-    descriptionClasses: "text-sm text-slate-300",
-    ctaContainerClasses: "flex flex-wrap gap-3 text-[0.7rem] uppercase tracking-[0.3em] text-slate-300",
-    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold hover:border-lime-300 hover:text-lime-200",
-    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold text-sky-300 hover:border-sky-400 hover:text-sky-200",
-    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold hover:border-lime-300 hover:text-lime-200"
+    articleClasses: "shell-card flex h-full flex-col justify-between gap-6 p-6",
+    metaClasses: "text-xs uppercase tracking-[0.35em] text-stone-500",
+    titleClasses: "text-2xl font-semibold text-stone-900",
+    titleLinkClasses: "transition hover:text-stone-600",
+    descriptionClasses: "text-sm text-stone-700",
+    ctaContainerClasses: "flex flex-wrap gap-3 text-[0.7rem] uppercase tracking-[0.2em] text-stone-700",
+    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-3 py-1 font-semibold hover:border-stone-500",
+    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-amber-400/70 bg-amber-50 px-3 py-1 font-semibold text-amber-800 hover:border-amber-500",
+    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-3 py-1 font-semibold hover:border-stone-500"
   },
   "standard": {
-    articleClasses: "flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-5 transition hover:border-slate-700 hover:bg-slate-900/60",
-    metaClasses: "text-xs uppercase tracking-[0.3em] text-slate-500",
-    titleClasses: "text-lg font-semibold text-slate-100",
-    titleLinkClasses: "transition hover:text-sky-300",
-    descriptionClasses: "text-sm text-slate-300",
+    articleClasses: "flex h-full flex-col justify-between gap-4 rounded-2xl border border-stone-300 bg-stone-50/90 p-5 transition hover:border-stone-500 hover:bg-stone-100/70",
+    metaClasses: "text-xs uppercase tracking-[0.3em] text-stone-500",
+    titleClasses: "text-lg font-semibold text-stone-900",
+    titleLinkClasses: "transition hover:text-stone-600",
+    descriptionClasses: "text-sm text-stone-700",
     ctaContainerClasses: "mt-auto flex flex-wrap gap-3 text-xs sm:text-sm",
-    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300",
-    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10",
-    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-300 px-3 py-1 font-semibold text-stone-700 transition hover:border-stone-500",
+    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-amber-400/80 bg-amber-50 px-3 py-1 font-semibold text-amber-800 transition hover:border-amber-500",
+    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-300 px-3 py-1 font-semibold text-stone-700 transition hover:border-stone-500"
   }
 } %}
 

--- a/src/layouts/external-post.njk
+++ b/src/layouts/external-post.njk
@@ -18,24 +18,22 @@ layout: base.njk
     <link rel="canonical" href="{{ redirectUrl | escape }}">
   {% endset %}
 {% endif %}
-<main class="px-3 py-8 sm:px-5 sm:py-10">
+<main class="px-4 py-8 sm:px-8 sm:py-10">
 {% from "components/blog-meta.njk" import renderPostHeader %}
-  <article
-    class="blog-post mx-auto flex max-w-3xl flex-col gap-10 rounded-3xl border border-slate-800/60 bg-slate-900/40 px-3 py-8 sm:px-5 sm:py-6"
-  >
+  <article class="blog-post shell-card mx-auto flex max-w-3xl flex-col gap-10 px-4 py-8 sm:px-6 sm:py-6">
     {{
       renderPostHeader(title, isoDate, displayDate, topicTagLinks, topicTags, {
         type: type,
         typeLabel: typeLabel,
         typeOptions: {
-          variantOverride: "border-amber-400/40 bg-amber-500/10 text-amber-100"
+          variantOverride: "border-amber-300 bg-amber-50 text-amber-800"
         }
       })
       | safe
     }}
-    <div class="space-y-6 rounded border border-amber-400/30 bg-amber-400/10 p-6 text-amber-100">
+    <div class="space-y-6 rounded border border-amber-300 bg-amber-50 p-6 text-amber-900">
       <p class="text-lg font-medium">{{ externalSourceMessage }}</p>
-      <p class="text-base text-amber-50/80">
+      <p class="text-base text-amber-900/80">
         {% if excerpt %}
           {{ excerpt }}
         {% else %}
@@ -43,19 +41,14 @@ layout: base.njk
         {% endif %}
       </p>
       {% if redirectUrl %}
-      <a
-        class="inline-flex items-center gap-2 rounded-md bg-amber-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-400"
-        href="{{ redirectUrl }}"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
+      <a class="inline-flex items-center gap-2 rounded-md border border-amber-400 bg-amber-100 px-4 py-2 text-sm font-semibold text-amber-900 transition hover:border-amber-500" href="{{ redirectUrl }}" rel="noopener noreferrer" target="_blank">
         {{ externalCtaLabel }}
         <span aria-hidden="true">↗</span>
       </a>
       {% endif %}
     </div>
     {% if content | trim %}
-    <div class="prose prose-invert prose-lg max-w-none">
+    <div class="prose prose-lg max-w-none">
       {{ content | safe }}
     </div>
     {% endif %}

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -1,22 +1,22 @@
 ---
 layout: base.njk
 ---
-<main class="px-6 py-16 sm:px-10">
+<main class="px-6 py-14 sm:px-10">
   <article class="mx-auto flex max-w-3xl flex-col gap-8">
     {% if title or sectionLabel or description %}
-      <header class="flex flex-col gap-4 text-slate-100">
+      <header class="flex flex-col gap-4 text-stone-900">
         {% if sectionLabel %}
-          <p class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">{{ sectionLabel }}</p>
+          <p class="text-sm font-semibold uppercase tracking-[0.3em] text-stone-500">{{ sectionLabel }}</p>
         {% endif %}
         {% if title %}
-          <h1 class="text-3xl font-semibold text-slate-100 sm:text-4xl">{{ title }}</h1>
+          <h1 class="text-3xl font-semibold text-stone-900 sm:text-4xl">{{ title }}</h1>
         {% endif %}
         {% if description %}
-          <p class="text-lg text-slate-300">{{ description }}</p>
+          <p class="text-lg text-stone-700">{{ description }}</p>
         {% endif %}
       </header>
     {% endif %}
-    <div class="prose prose-invert prose-lg max-w-none">
+    <div class="prose prose-lg max-w-none">
       {{ content | safe }}
     </div>
   </article>

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -1,20 +1,20 @@
 ---
 layout: base.njk
 ---
-<main class="px-3 py-8 sm:px-5 sm:py-10">
+<main class="px-4 py-8 sm:px-8 sm:py-10">
 {% from "components/blog-meta.njk" import renderPostHeader %}
-  <article class="blog-post mx-auto flex max-w-3xl flex-col gap-10 rounded-3xl border border-slate-800/60 bg-slate-900/40 px-3 py-8 sm:px-5 sm:py-6">
+  <article class="blog-post mx-auto flex max-w-3xl flex-col gap-10 shell-card px-3 py-8 sm:px-5 sm:py-6">
     {{
       renderPostHeader(title, isoDate, displayDate, topicTagLinks, topicTags, {
         type: type,
         typeLabel: typeLabel,
         typeOptions: {
-          variantOverride: "border-slate-700/70 bg-slate-900/70 text-slate-200"
+          variantOverride: "border-stone-300 bg-stone-100 text-stone-700"
         }
       })
       | safe
     }}
-    <div class="prose prose-invert prose-lg max-w-none">
+    <div class="prose prose-lg max-w-none">
       {{ content | safe }}
     </div>
 
@@ -28,7 +28,7 @@ layout: base.njk
         data-reactions-enabled="1"
         data-emit-metadata="0"
         data-input-position="bottom"
-        data-theme="dark"
+        data-theme="light"
         data-lang="en"
         crossorigin="anonymous"
         async>

--- a/src/layouts/work-item.njk
+++ b/src/layouts/work-item.njk
@@ -1,19 +1,19 @@
 ---
 layout: base.njk
 ---
-<main class="px-6 py-16 sm:px-10">
+<main class="px-6 py-14 sm:px-10">
   <article class="mx-auto flex max-w-3xl flex-col gap-10">
     <header class="space-y-4">
-      <a class="text-sm font-medium uppercase tracking-wide text-slate-400 hover:text-slate-200" href="/work/">Work</a>
-      <h1 class="text-4xl font-semibold tracking-tight text-slate-100">{{ title }}</h1>
+      <a class="text-sm font-medium uppercase tracking-wide text-stone-500 hover:text-stone-900" href="/work/">Work</a>
+      <h1 class="text-4xl font-semibold tracking-tight text-stone-900">{{ title }}</h1>
       {% if description %}
-      <p class="text-lg text-slate-300">{{ description }}</p>
+      <p class="text-lg text-stone-700">{{ description }}</p>
       {% endif %}
       {% if websiteUrl or githubUrl %}
       <div class="flex flex-wrap gap-3 text-sm">
         {% if websiteUrl %}
         <a
-          class="inline-flex items-center gap-2 rounded-full border border-sky-500 px-4 py-2 font-semibold text-sky-300 transition hover:bg-sky-500/10"
+          class="inline-flex items-center gap-2 rounded-full border border-amber-400 bg-amber-50 px-4 py-2 font-semibold text-amber-800 transition hover:border-amber-500"
           href="{{ websiteUrl }}"
           target="_blank"
           rel="noopener"
@@ -24,7 +24,7 @@ layout: base.njk
         {% endif %}
         {% if githubUrl %}
         <a
-          class="inline-flex items-center gap-2 rounded-full border border-slate-700 px-4 py-2 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+          class="inline-flex items-center gap-2 rounded-full border border-stone-300 px-4 py-2 font-semibold text-stone-700 transition hover:border-stone-500"
           href="{{ githubUrl }}"
           target="_blank"
           rel="noopener"
@@ -36,7 +36,7 @@ layout: base.njk
       </div>
       {% endif %}
     </header>
-    <div class="prose prose-invert prose-lg max-w-none">
+    <div class="prose prose-lg max-w-none">
       {{ content | safe }}
     </div>
   </article>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -6,17 +6,19 @@
 
 @layer base {
   :root {
-    color-scheme: dark;
+    color-scheme: light;
   }
 
   body {
-    @apply min-h-screen bg-slate-950 font-sans text-slate-100 antialiased selection:bg-sky-500/30 selection:text-slate-100;
-    background-image:
-      radial-gradient(circle at 20% 20%, rgba(125, 90, 240, 0.15), rgba(14, 23, 42, 0.1) 45%),
-      radial-gradient(circle at 80% 10%, rgba(19, 194, 194, 0.25), rgba(6, 11, 19, 0.05) 50%),
-      radial-gradient(circle at 50% 90%, rgba(148, 240, 90, 0.14), rgba(15, 23, 42, 0.1) 55%),
-      linear-gradient(180deg, rgba(10, 10, 20, 0.95), rgba(5, 9, 18, 0.92));
-    background-attachment: fixed;
+    @apply min-h-screen bg-stone-100 font-sans text-stone-800 antialiased selection:bg-amber-200 selection:text-stone-900;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: "Fraunces", serif;
+    letter-spacing: -0.01em;
   }
 
   a {
@@ -24,7 +26,11 @@
   }
 
   code {
-    @apply rounded-md bg-slate-900/70 px-1 py-0.5 font-mono text-sky-300;
+    @apply rounded-md bg-stone-200 px-1 py-0.5 font-mono text-stone-800;
+  }
+
+  .prose {
+    @apply prose-stone;
   }
 
   .prose code::before,
@@ -34,41 +40,22 @@
 }
 
 @layer components {
-  .glow-card {
-    @apply relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/40 p-6 shadow-glow transition-transform duration-300 ease-out;
-  }
-
-  .glow-card::before {
-    content: "";
+  .paper-grid {
     position: absolute;
-    inset: -40% -20%;
-    background: conic-gradient(
-      from 90deg,
-      rgba(125, 90, 240, 0.35),
-      rgba(19, 194, 194, 0.25),
-      rgba(25, 255, 182, 0.2),
-      rgba(125, 90, 240, 0.35)
-    );
-    opacity: 0.35;
-    filter: blur(60px);
-    transform: rotate(15deg);
-    transition: opacity 0.3s ease;
-    pointer-events: none;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(120, 113, 108, 0.06) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(120, 113, 108, 0.06) 1px, transparent 1px);
+    background-size: 2.4rem 2.4rem;
+    opacity: 0.45;
   }
 
-  .glow-card:hover {
-    transform: translateY(-6px) scale(1.01);
-  }
-
-  .glow-card:hover::before {
-    opacity: 0.6;
+  .shell-card {
+    @apply rounded-[2rem] border border-stone-300/80 bg-stone-50/90 shadow-[0_10px_35px_rgba(41,37,36,0.08)];
   }
 
   .terminal-panel {
-    @apply relative overflow-hidden rounded-3xl border border-lime-400/40 bg-slate-950/80 font-mono text-lime-200 shadow-glow;
-    box-shadow:
-      inset 0 0 40px rgba(56, 189, 248, 0.1),
-      0 0 80px rgba(125, 90, 240, 0.25);
+    @apply relative overflow-hidden rounded-[1.6rem] border border-stone-300 bg-stone-900 font-mono text-emerald-100 shadow-[0_14px_28px_rgba(28,25,23,0.24)];
   }
 
   .terminal-panel::after {
@@ -76,40 +63,34 @@
     position: absolute;
     inset: 0;
     background-image:
-      linear-gradient(rgba(148, 240, 90, 0.03) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(148, 240, 90, 0.03) 1px, transparent 1px);
-    background-size: 0.75rem 0.75rem;
-    mix-blend-mode: screen;
-    opacity: 0.8;
+      linear-gradient(rgba(16, 185, 129, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(16, 185, 129, 0.04) 1px, transparent 1px);
+    background-size: 0.85rem 0.85rem;
     pointer-events: none;
   }
 
   .terminal-header {
-    @apply flex items-center gap-2 border-b border-lime-400/30 bg-slate-900/60 px-6 py-3;
+    @apply flex items-center gap-2 border-b border-stone-700/70 bg-stone-800 px-6 py-3;
   }
 
   .terminal-dot {
     @apply inline-block h-3 w-3 rounded-full;
-    box-shadow: 0 0 10px rgba(148, 240, 90, 0.4);
   }
 
   .terminal-dot--close {
-    background-color: #ff5f57;
-    box-shadow: 0 0 8px rgba(255, 95, 87, 0.65);
+    background-color: #fb7185;
   }
 
   .terminal-dot--minimize {
-    background-color: #febb2e;
-    box-shadow: 0 0 8px rgba(254, 187, 46, 0.65);
+    background-color: #fbbf24;
   }
 
   .terminal-dot--zoom {
-    background-color: #28c840;
-    box-shadow: 0 0 8px rgba(40, 200, 64, 0.65);
+    background-color: #4ade80;
   }
 
   .terminal-body {
-    @apply flex flex-col gap-0 px-6 py-6 text-sm leading-relaxed text-lime-200/90;
+    @apply flex flex-col gap-0 px-6 py-6 text-sm leading-relaxed text-emerald-100/90;
   }
 
   .terminal-output {
@@ -121,21 +102,16 @@
   }
 
   .terminal-line__prompt {
-    @apply select-none text-lime-200/80;
+    @apply select-none text-emerald-200/80;
   }
 
   .terminal-line__command {
-    @apply text-fuchsia-300;
+    @apply text-amber-200;
   }
 
   .terminal-block {
-    @apply whitespace-pre-wrap break-words text-lime-100/90;
+    @apply whitespace-pre-wrap break-words text-emerald-50/90;
     margin: 0;
-  }
-
-  .terminal-form {
-    @apply pt-0;
-    border-top-width: 0;
   }
 
   .terminal-input-row {
@@ -143,8 +119,7 @@
   }
 
   .terminal-input {
-    @apply flex-1 bg-transparent font-mono text-sm text-lime-100 placeholder:text-lime-100/40 focus:outline-none;
-    caret-color: rgba(186, 230, 253, 0.9);
+    @apply flex-1 bg-transparent font-mono text-sm text-emerald-50 placeholder:text-emerald-100/40 focus:outline-none;
   }
 
   .terminal-block--pending {
@@ -152,74 +127,6 @@
   }
 
   .terminal-block--error {
-    @apply text-red-300;
-  }
-
-  .terminal-links {
-    @apply mt-4 flex flex-col gap-1;
-  }
-
-  .terminal-link {
-    @apply text-sm font-medium text-lime-100 transition hover:text-sky-200;
-  }
-
-  .skew-panel {
-    clip-path: polygon(0% 6%, 100% 0%, 100% 94%, 0% 100%);
-  }
-
-  .grid-overlay {
-    position: absolute;
-    inset: -50% -50%;
-    background-image:
-      linear-gradient(rgba(125, 90, 240, 0.2) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(19, 194, 194, 0.2) 1px, transparent 1px);
-    background-size: 90px 90px;
-    opacity: 0.15;
-    animation: gridShift 16s linear infinite;
-    pointer-events: none;
-  }
-
-  .accent-stripe {
-    position: relative;
-    isolation: isolate;
-  }
-
-  .accent-stripe::before {
-    content: "";
-    position: absolute;
-    inset: -20px -40px;
-    background: linear-gradient(135deg, rgba(125, 90, 240, 0.6), rgba(19, 194, 194, 0.3));
-    filter: blur(60px);
-    opacity: 0.55;
-    transform: skewY(-6deg);
-    z-index: -1;
-  }
-}
-
-@layer utilities {
-  .perspective-1200 {
-    perspective: 1200px;
-  }
-
-  .backface-hidden {
-    backface-visibility: hidden;
-  }
-
-  .parallax {
-    position: relative;
-    transform-style: preserve-3d;
-  }
-
-  .parallax-layer {
-    position: absolute;
-    inset: 0;
-    will-change: transform;
-    pointer-events: none;
-  }
-
-  .dot-matrix {
-    background-image: radial-gradient(rgba(148, 240, 90, 0.35) 1px, transparent 1px);
-    background-size: 8px 8px;
-    opacity: 0.5;
+    @apply text-rose-200;
   }
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,7 +10,7 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: [
-          '"Space Grotesk"',
+          '"Inter"',
           '"Poppins"',
           "ui-sans-serif",
           "system-ui",


### PR DESCRIPTION
### Motivation
- Replace the existing neon/cyberpunk palette and heavy glow effects with a calmer, lighter editorial visual system to improve legibility and reduce the ‘tacky’ neon look. 
- Introduce a coherent typographic and card-based hierarchy so content (blog, work, pages) reads consistently across templates. 
- Preserve interactive features (hero orb, terminal) while making them visually restrained and accessible in a light theme. 

### Description
- Reworked the global shell and styles: replaced dark neon background with a light `stone`/`amber` palette, added a subtle `paper-grid` backdrop, and swapped fonts to `Fraunces` + `Inter` + `IBM Plex Mono` (`src/layouts/base.njk`, `src/styles/tailwind.css`, `tailwind.config.cjs`).
- Rebuilt homepage sections from scratch: simplified hero layout, toned orb container, and redesigned CTA/terminal visuals (`src/layouts/components/home/hero.njk`, `src/layouts/components/home/featured-work.njk`, `src/layouts/components/home/recent-posts.njk`, `src/layouts/components/home/social.njk`).
- Updated shared components and macros to the new system: replaced glow cards with `shell-card`, adjusted work card variants, post list styles, tag/ badge variants, and CTA classes for consistent contrast (`src/layouts/components/work-card.njk`, `src/layouts/components/post-list.njk`, `src/layouts/components/blog-meta.njk`).
- Adjusted page/post/work/external templates and archive UI to match the redesign and switched Giscus to the light theme for compatibility (`src/layouts/post.njk`, `src/layouts/external-post.njk`, `src/layouts/blog-list.njk`, `content/work/index.njk`, `src/layouts/page.njk`, `src/layouts/work-item.njk`).

### Testing
- Ran `npm run check` (Biome): completed with no issues. (passed)
- Ran `npm test` (Vitest): all tests passed (`functions/terminal-chat.test.ts` suite passed). (passed)
- Built the site with `npm run build` (Tailwind + Eleventy): site generated successfully and files written to `_site`. (passed)
- Attempted visual screenshot via Playwright (`npx playwright screenshot ...`) but the browser download failed in this environment (Playwright download blocked with HTTP 403); attempted `npx playwright install chromium` also failed for the same reason (download blocked). (visual snapshot failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0565d7c9c832bb4492f4c6bcce3dd)