### PR TITLE
Redesign site with a calmer editorial visual language

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full bg-slate-950">
+<html lang="en" class="h-full bg-stone-100">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&display=swap"
     rel="stylesheet"
   >
   <link rel="stylesheet" href="/style.css">
@@ -22,32 +22,15 @@
   {% endif %}
 </head>
 <body class="relative min-h-screen overflow-x-hidden">
-  <div aria-hidden="true" class="pointer-events-none fixed inset-0 overflow-hidden">
-    <div class="grid-overlay"></div>
-    <div class="absolute -left-40 top-1/4 h-96 w-96 rounded-full bg-sky-400/20 blur-3xl"></div>
-    <div class="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-fuchsia-500/20 blur-3xl"></div>
-    <svg class="absolute -top-20 right-0 h-[540px] w-[540px] opacity-40" viewBox="0 0 400 400" fill="none">
-      <defs>
-        <linearGradient id="diagonalGradient" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0%" stop-color="#7D5AF0" stop-opacity="0.6" />
-          <stop offset="50%" stop-color="#13C2C2" stop-opacity="0.3" />
-          <stop offset="100%" stop-color="#19FFB6" stop-opacity="0.2" />
-        </linearGradient>
-      </defs>
-      <path d="M0 140 L400 0 L400 260 L0 400 Z" fill="url(#diagonalGradient)" />
-      <path d="M-40 120 L400 -20" stroke="#13C2C2" stroke-width="2" stroke-opacity="0.4" stroke-dasharray="10 14" />
-      <path d="M-60 220 L420 60" stroke="#7D5AF0" stroke-width="1.5" stroke-opacity="0.5" stroke-dasharray="6 12" />
-    </svg>
-  </div>
   <div class="relative z-10 flex min-h-screen flex-col">
-    <header class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pb-8 pt-10 sm:flex-row sm:items-center sm:justify-between sm:px-10">
-      <a href="/" class="text-sm font-semibold uppercase tracking-[0.35em] text-slate-200 transition hover:text-lime-300">
+    <header class="mx-auto flex w-full max-w-6xl flex-col gap-5 px-6 pb-10 pt-10 sm:flex-row sm:items-end sm:justify-between sm:px-10">
+      <a href="/" class="text-link text-sm font-semibold uppercase tracking-[0.28em]">
         dave.engineer
       </a>
       {% if navigation and navigation | length %}
-      <nav class="flex flex-wrap items-center gap-6 text-sm font-medium text-slate-200/90">
+      <nav class="flex flex-wrap items-center gap-5 text-sm font-medium text-stone-600">
         {% for link in navigation %}
-        <a class="hover:text-lime-300" href="{{ link.href }}">{{ link.label }}</a>
+        <a class="text-link" href="{{ link.href }}">{{ link.label }}</a>
         {% endfor %}
       </nav>
       {% endif %}
@@ -55,17 +38,17 @@
     <main class="flex-1">
       {{ content | safe }}
     </main>
-    <footer class="border-t border-slate-800/40 bg-slate-950/80">
-      <div class="mx-auto flex max-w-6xl flex-col gap-5 px-6 py-10 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-10">
-        <nav class="flex flex-wrap items-center gap-5 text-sm font-medium text-slate-300">
-          <a class="hover:text-lime-300" href="/">dave.engineer</a>
+    <footer class="mt-10 border-t border-stone-300/80">
+      <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-10 text-sm text-stone-500 sm:flex-row sm:items-center sm:justify-between sm:px-10">
+        <nav class="flex flex-wrap items-center gap-5 text-sm font-medium text-stone-600">
+          <a class="text-link" href="/">dave.engineer</a>
           {% if navigation and navigation | length %}
             {% for link in navigation %}
-            <a class="hover:text-lime-300" href="{{ link.href }}">{{ link.label }}</a>
+            <a class="text-link" href="{{ link.href }}">{{ link.label }}</a>
             {% endfor %}
           {% endif %}
         </nav>
-        <p class="text-xs text-slate-500">© Dave Hulbert</p>
+        <p class="text-xs">© Dave Hulbert</p>
       </div>
     </footer>
   </div>

--- a/src/layouts/blog-list.njk
+++ b/src/layouts/blog-list.njk
@@ -14,59 +14,48 @@ layout: base.njk
 {% endfor %}
 {% set tagList = collections.blogTags | default([]) %}
 {% set tagLinkClasses = tagClasses() %}
-{% set tagCountClasses = "rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] font-medium text-slate-400" %}
-{% set paginationButtonClasses = "inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1 text-sm font-medium text-slate-300 transition hover:border-slate-600 hover:text-slate-100" %}
-{% set paginationActiveClasses = "border-sky-500/80 text-sky-200" %}
-<main class="px-6 py-16 sm:px-10">
-  <div class="mx-auto flex max-w-4xl flex-col gap-12">
+{% set tagCountClasses = "rounded-full border border-stone-300 bg-stone-100 px-2 py-0.5 text-[0.65rem] font-medium text-stone-500" %}
+{% set paginationButtonClasses = "inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700 transition hover:border-stone-500 hover:text-stone-900" %}
+{% set paginationActiveClasses = "border-stone-900 text-stone-900" %}
+<main class="px-6 py-10 sm:px-10 sm:py-14">
+  <div class="mx-auto flex max-w-4xl flex-col gap-10">
     <header class="space-y-4">
-      <a
-        class="inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300"
-        href="/"
-      >
+      <a class="text-link inline-flex items-center gap-2 text-sm font-medium" href="/">
         <span aria-hidden="true">←</span>
         Back to home
       </a>
-      <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-400">Archive</p>
-      <h1 class="text-4xl font-semibold tracking-tight text-slate-100">{{ listTitle or "Writing" }}</h1>
+      <p class="section-kicker">Archive</p>
+      <h1 class="font-serif text-5xl tracking-tight text-stone-900">{{ listTitle or "Writing" }}</h1>
       {% if listDescription %}
-        <p class="text-lg text-slate-300">{{ listDescription }}</p>
+        <p class="max-w-2xl text-lg text-stone-600">{{ listDescription }}</p>
       {% endif %}
     </header>
 
     {% if typeGroups | length %}
-    <nav aria-label="Filter posts by type" class="flex flex-col gap-3">
-      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Filter by type</p>
+    <nav aria-label="Filter posts by type" class="space-y-3">
+      <p class="section-kicker">Filter by type</p>
       <ul class="flex flex-wrap gap-2">
         <li>
           {% set isAllActive = not currentType %}
           <a
             href="/blog/"
-            class="inline-flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-slate-700 hover:text-slate-100 {{ "border-sky-500/80 text-sky-200" if isAllActive }}"
+            class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-stone-700 transition hover:border-stone-500 hover:text-stone-900 {{ "border-stone-900 text-stone-900" if isAllActive }}"
             {% if isAllActive %}aria-current="page"{% endif %}
           >
             All
-            <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] font-medium text-slate-400">{{ totalCount }}</span>
+            <span class="{{ tagCountClasses }}">{{ totalCount }}</span>
           </a>
         </li>
         {% for group in typeGroups %}
         <li>
           {% set isActive = currentType == group.type %}
-          {% set badgeClasses = "" %}
-          {% if group.type == "post" %}
-            {% set badgeClasses = "border-sky-500/80 text-sky-200" %}
-          {% elseif group.type == "til" %}
-            {% set badgeClasses = "border-lime-500/80 text-lime-200" %}
-          {% elseif group.type == "external" %}
-            {% set badgeClasses = "border-amber-500/80 text-amber-200" %}
-          {% endif %}
           <a
             href="{{ group.permalink }}"
-            class="inline-flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-slate-700 hover:text-slate-100 {{ badgeClasses if isActive }}"
+            class="inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-stone-700 transition hover:border-stone-500 hover:text-stone-900 {{ "border-stone-900 text-stone-900" if isActive }}"
             {% if isActive %}aria-current="page"{% endif %}
           >
             {{ group.label }}
-            <span class="rounded-full border border-slate-700/60 bg-slate-950/60 px-2 py-0.5 text-[0.65rem] font-medium text-slate-400">{{ group.count }}</span>
+            <span class="{{ tagCountClasses }}">{{ group.count }}</span>
           </a>
         </li>
         {% endfor %}
@@ -78,15 +67,15 @@ layout: base.njk
     {% set tagPreview = tagList.slice(0, 12) %}
     <section class="space-y-3">
       <div class="flex items-center justify-between gap-4">
-        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Browse by tag</p>
-        <a class="text-xs font-semibold tracking-wide text-sky-300 transition hover:text-sky-200" href="/blog/tag/">View all tags →</a>
+        <p class="section-kicker">Browse by tag</p>
+        <a class="text-link text-xs font-semibold tracking-wide" href="/blog/tag/">View all tags →</a>
       </div>
       <div class="{{ tagContainerClasses() }}">
         {% for tag in tagPreview %}
         {% set isCurrentTag = currentTagSlug and currentTagSlug == tag.slug %}
         <a
           href="{{ tag.permalink }}"
-          class="{{ tagLinkClasses }} {{ "border-sky-500/80 text-sky-200" if isCurrentTag }}"
+          class="{{ tagLinkClasses }} {{ "border-stone-900 text-stone-900" if isCurrentTag }}"
           {% if isCurrentTag %}aria-current="page"{% endif %}
         >
           {{ tag.name | lower }}
@@ -98,18 +87,19 @@ layout: base.njk
     {% endif %}
 
     {% if content | trim %}
-      <div class="prose prose-invert max-w-none">{{ content | safe }}</div>
+      <div class="prose max-w-none">{{ content | safe }}</div>
     {% endif %}
 
     {{ renderPostList(postsToRender, {
       tagLinkClasses: tagLinkClasses,
       showEmptyMessage: true,
-      emptyMessage: "No posts found."
+      emptyMessage: "No posts found.",
+      containerClasses: "paper-frame flex flex-col divide-y divide-stone-200 overflow-hidden"
     }) | safe }}
 
     {% if listingPagination and listingPagination.totalPages > 1 %}
-    <nav aria-label="Pagination" class="flex flex-col items-center gap-3 pt-6">
-      <p class="text-sm text-slate-400">Page {{ listingPagination.currentPage }} of {{ listingPagination.totalPages }}</p>
+    <nav aria-label="Pagination" class="flex flex-col items-center gap-3 pt-4">
+      <p class="text-sm text-stone-500">Page {{ listingPagination.currentPage }} of {{ listingPagination.totalPages }}</p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         {% if listingPagination.previous %}
         <a class="{{ paginationButtonClasses }}" href="{{ listingPagination.previous.url }}">

--- a/src/layouts/components/blog-meta.njk
+++ b/src/layouts/components/blog-meta.njk
@@ -1,5 +1,5 @@
 {% set DEFAULT_TAG_CONTAINER_CLASSES = "flex flex-wrap gap-2" %}
-{% set DEFAULT_TAG_CLASSES = "inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1 text-xs font-semibold tracking-wide text-slate-300 transition hover:border-slate-600 hover:text-slate-100" %}
+{% set DEFAULT_TAG_CLASSES = "inline-flex items-center gap-2 rounded-full border border-stone-300 bg-stone-100 px-3 py-1 text-xs font-semibold tracking-wide text-stone-700 transition hover:border-stone-500 hover:text-stone-900" %}
 {% set DEFAULT_TYPE_BASE_CLASSES = "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide" %}
 
 {% macro tagContainerClasses(extra = "") %}
@@ -43,19 +43,18 @@
 
 {% macro renderPostHeader(title, isoDate, displayDate, topicTagLinks = [], topicTags = [], options = {}) %}
   {% set containerClasses = options.containerClasses or "space-y-5" %}
-  {% set headingClasses = options.headingClasses or "text-4xl font-semibold tracking-tight text-slate-100" %}
+  {% set headingClasses = options.headingClasses or "font-serif text-5xl tracking-tight text-stone-900" %}
   {% set breadcrumbHref = options.breadcrumbHref or "/blog/" %}
   {% set breadcrumbLabel = options.breadcrumbLabel or "Blog" %}
   {% set showBreadcrumb = options.showBreadcrumb | default(true) %}
-  {% set dateClasses = options.dateClasses or "text-base text-slate-400" %}
-  {% set metadataRowClasses = options.metadataRowClasses or "flex flex-wrap items-center gap-3 text-sm text-slate-400" %}
+  {% set metadataRowClasses = options.metadataRowClasses or "flex flex-wrap items-center gap-3 text-sm text-stone-500" %}
   {% set typeOptions = options.typeOptions or {} %}
   {% set typeValue = options.type or options.postType %}
   {% set typeLabel = options.typeLabel or options.postTypeLabel %}
   {% set showType = options.showTypeBadge | default(typeValue or typeLabel) %}
   <header class="{{ containerClasses }}">
     {% if showBreadcrumb %}
-    <a class="text-sm font-medium uppercase tracking-wide text-slate-400 hover:text-slate-200" href="{{ breadcrumbHref }}">{{ breadcrumbLabel }}</a>
+    <a class="text-link text-sm font-medium uppercase tracking-wide" href="{{ breadcrumbHref }}">{{ breadcrumbLabel }}</a>
     {% endif %}
     <h1 class="{{ headingClasses }}">{{ title }}</h1>
     {% if displayDate or showType %}
@@ -80,9 +79,9 @@
   {% set baseClasses = options.baseClasses or DEFAULT_TYPE_BASE_CLASSES %}
   {% set extraClasses = options.extraClasses or "" %}
   {% set variants = {
-    "post": "border-sky-400/40 bg-sky-500/10 text-sky-200",
-    "til": "border-lime-400/40 bg-lime-400/10 text-lime-100",
-    "external": "border-amber-400/40 bg-amber-400/10 text-amber-100"
+    "post": "border-stone-300 bg-stone-100 text-stone-700",
+    "til": "border-emerald-300 bg-emerald-50 text-emerald-700",
+    "external": "border-amber-300 bg-amber-50 text-amber-700"
   } %}
   {% set typeKey = (type | default('post')) | lower %}
   {% set labelMap = {
@@ -96,7 +95,7 @@
 {% endmacro %}
 
 {% macro renderPostCta(url, label, options = {}) %}
-  {% set classes = options.classes or "inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300" %}
+  {% set classes = options.classes or "inline-flex items-center gap-2 text-sm font-medium text-stone-700 hover:text-stone-900" %}
   {% set icon = options.icon or "→" %}
   {% set rel = options.rel %}
   {% set target = options.target %}

--- a/src/layouts/components/home/featured-work.njk
+++ b/src/layouts/components/home/featured-work.njk
@@ -8,27 +8,23 @@
     {% endif %}
   {% endfor %}
   {% if featuredItems | length %}
-  <section class="space-y-10">
-    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+  <section class="space-y-8">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
       <div class="space-y-2">
         {% if config.sectionLabel %}
-        <p class="text-xs uppercase tracking-[0.45em] text-slate-500">{{ config.sectionLabel }}</p>
+        <p class="section-kicker">{{ config.sectionLabel }}</p>
         {% endif %}
         {% if config.sectionTitle %}
-        <h2 class="text-3xl font-semibold text-slate-100">{{ config.sectionTitle }}</h2>
+        <h2 class="font-serif text-4xl text-stone-900">{{ config.sectionTitle }}</h2>
         {% endif %}
       </div>
       {% if config.viewAllHref and config.viewAllLabel %}
-      <a
-        class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-lime-300 hover:text-lime-200"
-        href="{{ config.viewAllHref }}"
-      >
-        {{ config.viewAllLabel }}
-        <span aria-hidden="true">→</span>
+      <a class="text-link text-sm font-semibold uppercase tracking-[0.2em]" href="{{ config.viewAllHref }}">
+        {{ config.viewAllLabel }} →
       </a>
       {% endif %}
     </div>
-    <div class="grid gap-6 md:grid-cols-2">
+    <div class="grid gap-5 md:grid-cols-2">
       {% for item in featuredItems %}
         {{
           renderWorkCard(item, {

--- a/src/layouts/components/home/hero.njk
+++ b/src/layouts/components/home/hero.njk
@@ -1,87 +1,67 @@
 {% macro renderHomeHero(hero) %}
-  <section class="relative overflow-hidden rounded-[2.75rem] border border-slate-800/60 bg-slate-950/70 p-4 pt-10 shadow-glow sm:p-16 sm:pt-14" data-parallax-root>
-    <div class="pointer-events-none absolute inset-0 opacity-50 parallax" data-parallax>
-      <svg class="absolute -top-32 left-1/2 h-[420px] -translate-x-1/2" viewBox="0 0 600 400" fill="none" data-parallax-depth="0.08">
-        <g stroke="rgba(125,90,240,0.4)" stroke-width="1">
-          <path d="M0 120 L580 0" />
-          <path d="M0 180 L580 60" />
-          <path d="M0 240 L580 120" />
-          <path d="M0 300 L580 180" />
-        </g>
-        <g stroke="rgba(25,255,182,0.25)" stroke-width="1" stroke-dasharray="12 16">
-          <path d="M40 400 L600 40" />
-          <path d="M120 420 L600 120" />
-        </g>
-      </svg>
-      <div class="absolute inset-0 -skew-y-3 bg-gradient-to-br from-slate-900/10 via-fuchsia-500/10 to-sky-500/10 mix-blend-screen" data-parallax-depth="0.05"></div>
-      <div class="absolute -bottom-24 left-12 h-44 w-44 rounded-full bg-sky-400/20 blur-3xl" data-parallax-depth="0.12"></div>
-      <div class="absolute -top-16 right-6 h-56 w-56 -skew-y-12 rounded-3xl border border-sky-300/40" data-parallax-depth="0.18"></div>
-    </div>
-    <div class="relative z-10 grid gap-16 lg:grid-cols-[minmax(0,1.15fr)_380px]">
-      <div class="space-y-10">
-        <div class="space-y-6">
-          {% if hero.badgeLabel %}
-          <p class="inline-flex items-center gap-3 rounded-full border border-lime-400/40 bg-slate-900/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-lime-300">
-            <span class="inline-flex h-2 w-2 rounded-full bg-lime-300 shadow-glow"></span>
-            {{ hero.badgeLabel }}
-          </p>
-          {% endif %}
-          <div class="flex flex-col gap-6 sm:flex-row sm:items-center">
-            <img
-              src="/img/dave.jpg"
-              alt="Dave Hulbert"
-              width="132"
-              height="132"
-              class="h-28 w-28 rounded-full border border-lime-300/40 bg-slate-900/60 object-cover shadow-glow"
-              loading="lazy"
-            >
-            <div class="space-y-4">
-              {% if hero.name %}
-              <h1 class="text-balance text-4xl font-semibold leading-tight tracking-tight text-slate-100 sm:text-5xl lg:text-6xl">
-                {{ hero.name }}
-              </h1>
-              {% endif %}
-              {% if hero.subtitle %}
-              <p class="text-lg font-medium uppercase tracking-[0.3em] text-slate-300">{{ hero.subtitle }}</p>
-              {% endif %}
-            </div>
+  <section class="paper-frame p-6 sm:p-10 lg:p-12">
+    <div class="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_380px] lg:items-start">
+      <div class="space-y-8">
+        {% if hero.badgeLabel %}
+        <p class="section-kicker">{{ hero.badgeLabel }}</p>
+        {% endif %}
+
+        <div class="flex flex-col gap-5 sm:flex-row sm:items-center">
+          <img
+            src="/img/dave.jpg"
+            alt="Dave Hulbert"
+            width="132"
+            height="132"
+            class="h-24 w-24 rounded-full border border-stone-300 object-cover sm:h-28 sm:w-28"
+            loading="lazy"
+          >
+          <div class="space-y-3">
+            {% if hero.name %}
+            <h1 class="font-serif text-5xl leading-none tracking-tight text-stone-900 sm:text-6xl lg:text-7xl">
+              {{ hero.name }}
+            </h1>
+            {% endif %}
+            {% if hero.subtitle %}
+            <p class="text-sm font-semibold uppercase tracking-[0.2em] text-stone-500">{{ hero.subtitle }}</p>
+            {% endif %}
           </div>
         </div>
+
         {% if hero.paragraphs and hero.paragraphs | length %}
-        <div class="space-y-6 text-lg text-slate-300">
+        <div class="max-w-2xl space-y-5 text-lg leading-relaxed text-stone-700">
           {% for paragraph in hero.paragraphs %}
           <p>{{ paragraph }}</p>
           {% endfor %}
         </div>
         {% endif %}
+
         {% if hero.ctas and hero.ctas | length %}
-        <div class="flex flex-wrap items-center gap-5">
+        <div class="flex flex-wrap items-center gap-4">
           {% for cta in hero.ctas %}
           <a
-            class="inline-flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.3em] text-sky-300 transition hover:text-lime-200"
+            class="inline-flex items-center gap-2 rounded-full border border-stone-400/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-stone-700 hover:border-stone-900 hover:text-stone-900"
             href="{{ cta.href }}"
           >
             {{ cta.label }}
             {% if cta.trailingIcon %}
-            <span aria-hidden="true" class="text-base">{{ cta.trailingIcon }}</span>
+            <span aria-hidden="true">{{ cta.trailingIcon }}</span>
             {% endif %}
           </a>
           {% endfor %}
         </div>
         {% endif %}
       </div>
-      <div class="relative flex flex-col items-center justify-between gap-6">
-        <div class="perspective-1200 relative h-[340px] w-full max-w-[420px]">
-          <div class="absolute inset-0 rounded-[2rem] border border-slate-800/60 bg-hero-radial"></div>
-          <canvas id="hero-orb" class="relative h-full w-full rounded-[2rem]"></canvas>
-          <div class="pointer-events-none absolute inset-0 rounded-[2rem] border border-fuchsia-500/20"></div>
+
+      <div class="space-y-5">
+        <div class="rounded-2xl border border-stone-300 bg-stone-200/40 p-2">
+          <canvas id="hero-orb" class="h-[280px] w-full rounded-xl"></canvas>
         </div>
-        <div class="terminal-panel w-full max-w-[420px]" data-terminal-root>
+        <div class="terminal-panel" data-terminal-root>
           <div class="terminal-header">
             <span class="terminal-dot terminal-dot--close" aria-hidden="true"></span>
             <span class="terminal-dot terminal-dot--minimize" aria-hidden="true"></span>
             <span class="terminal-dot terminal-dot--zoom" aria-hidden="true"></span>
-            <p class="ml-3 text-xs uppercase tracking-[0.4em] text-lime-200/80">Interactive Terminal</p>
+            <p class="ml-2 text-[0.65rem] uppercase tracking-[0.22em] text-stone-400">Assistant shell</p>
           </div>
           <div class="terminal-body" data-terminal>
             <div class="terminal-output" data-terminal-output>

--- a/src/layouts/components/home/recent-posts.njk
+++ b/src/layouts/components/home/recent-posts.njk
@@ -2,29 +2,25 @@
 
 {% macro renderRecentPostsSection(posts, config) %}
   {% if posts and posts | length %}
-  <section class="relative space-y-8">
+  <section class="space-y-8">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
       <div class="space-y-2">
         {% if config.sectionLabel %}
-        <p class="text-xs uppercase tracking-[0.45em] text-slate-500">{{ config.sectionLabel }}</p>
+        <p class="section-kicker">{{ config.sectionLabel }}</p>
         {% endif %}
         {% if config.sectionTitle %}
-        <h2 class="text-3xl font-semibold text-slate-100">{{ config.sectionTitle }}</h2>
+        <h2 class="font-serif text-4xl text-stone-900">{{ config.sectionTitle }}</h2>
         {% endif %}
       </div>
       {% if config.viewAllHref and config.viewAllLabel %}
-      <a
-        class="inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-lime-300 hover:text-lime-200"
-        href="{{ config.viewAllHref }}"
-      >
-        {{ config.viewAllLabel }}
-        <span aria-hidden="true">→</span>
+      <a class="text-link text-sm font-semibold uppercase tracking-[0.2em]" href="{{ config.viewAllHref }}">
+        {{ config.viewAllLabel }} →
       </a>
       {% endif %}
     </div>
     {{ renderPostList(posts, {
-      containerClasses: "flex flex-col divide-y divide-slate-800/80 overflow-hidden rounded-[2rem] border border-slate-800/60 bg-slate-950/40",
-      articleClasses: "group flex flex-col gap-3 px-6 py-6 transition hover:bg-slate-900/70 sm:px-8",
+      containerClasses: "paper-frame flex flex-col divide-y divide-stone-200 overflow-hidden",
+      articleClasses: "group flex flex-col gap-3 px-6 py-6 transition hover:bg-stone-100 sm:px-8",
       headingLevel: "h3",
       truncateLength: 180
     }) | safe }}

--- a/src/layouts/components/home/social.njk
+++ b/src/layouts/components/home/social.njk
@@ -1,23 +1,22 @@
 {% macro renderSocialSection(config, links) %}
   {% if links and links | length %}
-  <section class="relative rounded-[2.75rem] border border-slate-800/60 bg-slate-950/70 p-4 shadow-glow sm:p-16">
-    <div class="absolute inset-0 dot-matrix rounded-[2.75rem] opacity-20"></div>
-    <div class="relative z-10 space-y-6">
+  <section class="paper-frame p-6 sm:p-10">
+    <div class="space-y-6">
       {% if config.sectionLabel %}
-      <p class="text-xs uppercase tracking-[0.45em] text-slate-500">{{ config.sectionLabel }}</p>
+      <p class="section-kicker">{{ config.sectionLabel }}</p>
       {% endif %}
       {% if config.sectionTitle %}
-      <h2 class="text-3xl font-semibold text-slate-100">{{ config.sectionTitle }}</h2>
+      <h2 class="font-serif text-4xl text-stone-900">{{ config.sectionTitle }}</h2>
       {% endif %}
-      <div class="grid gap-4 sm:grid-cols-2">
+      <div class="grid gap-3 sm:grid-cols-2">
         {% for link in links %}
         <a
           href="{{ link.href }}"
           target="_blank"
           rel="noopener"
-          class="glow-card flex flex-col gap-2 border-slate-700/60"
+          class="rounded-2xl border border-stone-300 bg-stone-100/70 px-5 py-4 text-base font-medium text-stone-700 hover:border-stone-500 hover:text-stone-950"
         >
-          <h3 class="text-lg font-semibold text-slate-100">{{ link.label }}</h3>
+          {{ link.label }}
         </a>
         {% endfor %}
       </div>

--- a/src/layouts/components/post-list.njk
+++ b/src/layouts/components/post-list.njk
@@ -1,15 +1,15 @@
 {% from "components/blog-meta.njk" import renderPostTypeBadge, renderTagList, renderPostCta, tagClasses, tagContainerClasses %}
 {% macro renderPostList(posts = [], options = {}) %}
   {% set items = posts | default([]) %}
-  {% set containerClasses = options.containerClasses or "flex flex-col divide-y divide-slate-800/80 border border-slate-800/60 bg-slate-900/40" %}
-  {% set articleClasses = options.articleClasses or "group flex flex-col gap-3 px-6 py-6 transition hover:bg-slate-900/70 sm:px-8" %}
+  {% set containerClasses = options.containerClasses or "paper-frame flex flex-col divide-y divide-stone-200 overflow-hidden" %}
+  {% set articleClasses = options.articleClasses or "group flex flex-col gap-3 px-6 py-6 transition hover:bg-stone-100 sm:px-8" %}
   {% set headingLevel = options.headingLevel or "h2" %}
   {% set truncateLength = options.truncateLength or 220 %}
   {% set showEmptyMessage = options.showEmptyMessage | default(false) %}
   {% set emptyMessage = options.emptyMessage or "No posts found." %}
   {% set tagLinkClasses = options.tagLinkClasses or tagClasses() %}
   {% set tagListClasses = options.tagListClasses or tagContainerClasses() %}
-  {% set ctaClasses = options.ctaClasses or "mt-2 inline-flex items-center gap-2 text-sm font-medium text-sky-400 hover:text-sky-300" %}
+  {% set ctaClasses = options.ctaClasses or "mt-2 inline-flex items-center gap-2 text-sm font-medium text-stone-700 hover:text-stone-900" %}
   <div class="{{ containerClasses }}">
     {% if items | length %}
       {% for post in items %}
@@ -42,7 +42,7 @@
           {% set ctaRel = "noopener noreferrer" %}
         {% endif %}
         <article class="{{ articleClasses }}">
-          <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400">
+          <div class="flex flex-wrap items-center justify-between gap-3 text-sm text-stone-500">
             <div class="flex flex-wrap items-center gap-3">
               {{ renderPostTypeBadge(post.data.type, typeLabel) | safe }}
               <time datetime="{{ post.data.isoDate }}">{{ post.data.displayDate }}</time>
@@ -52,11 +52,11 @@
               tagClasses: tagLinkClasses
             }) | safe }}
           </div>
-          <{{ headingLevel }} class="text-2xl font-semibold tracking-tight text-slate-100">
-            <a class="block transition hover:text-sky-300" href="{{ post.url }}">{{ post.data.title }}</a>
+          <{{ headingLevel }} class="font-serif text-3xl tracking-tight text-stone-900">
+            <a class="block text-link" href="{{ post.url }}">{{ post.data.title }}</a>
           </{{ headingLevel }}>
           {% if summary %}
-          <p class="text-base text-slate-300">{{ summary }}</p>
+          <p class="text-base leading-relaxed text-stone-700">{{ summary }}</p>
           {% endif %}
           {{ renderPostCta(ctaUrl, ctaLabel, {
             classes: ctaClasses,
@@ -66,7 +66,7 @@
         </article>
       {% endfor %}
     {% elseif showEmptyMessage %}
-      <p class="px-6 py-10 text-center text-sm text-slate-400 sm:px-8">{{ emptyMessage }}</p>
+      <p class="px-6 py-10 text-center text-sm text-stone-500 sm:px-8">{{ emptyMessage }}</p>
     {% endif %}
   </div>
 {% endmacro %}

--- a/src/layouts/components/work-card.njk
+++ b/src/layouts/components/work-card.njk
@@ -1,25 +1,25 @@
 {% set WORK_CARD_VARIANTS = {
   "featured": {
-    articleClasses: "glow-card flex h-full flex-col justify-between gap-6 border-slate-800/80",
-    metaClasses: "text-xs uppercase tracking-[0.4em] text-slate-500",
-    titleClasses: "text-2xl font-semibold text-slate-100",
-    titleLinkClasses: "transition hover:text-lime-200",
-    descriptionClasses: "text-sm text-slate-300",
-    ctaContainerClasses: "flex flex-wrap gap-3 text-[0.7rem] uppercase tracking-[0.3em] text-slate-300",
-    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold hover:border-lime-300 hover:text-lime-200",
-    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold text-sky-300 hover:border-sky-400 hover:text-sky-200",
-    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700/80 px-3 py-1 font-semibold hover:border-lime-300 hover:text-lime-200"
+    articleClasses: "paper-frame flex h-full flex-col justify-between gap-6 p-6",
+    metaClasses: "text-xs uppercase tracking-[0.24em] text-stone-500",
+    titleClasses: "font-serif text-3xl text-stone-900",
+    titleLinkClasses: "text-link",
+    descriptionClasses: "text-base leading-relaxed text-stone-700",
+    ctaContainerClasses: "flex flex-wrap gap-3 text-xs uppercase tracking-[0.2em]",
+    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-400 px-3 py-1.5 font-semibold text-stone-700 hover:border-stone-900 hover:text-stone-900",
+    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-400 px-3 py-1.5 font-semibold text-stone-700 hover:border-stone-900 hover:text-stone-900",
+    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-400 px-3 py-1.5 font-semibold text-stone-700 hover:border-stone-900 hover:text-stone-900"
   },
   "standard": {
-    articleClasses: "flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-900/40 p-5 transition hover:border-slate-700 hover:bg-slate-900/60",
-    metaClasses: "text-xs uppercase tracking-[0.3em] text-slate-500",
-    titleClasses: "text-lg font-semibold text-slate-100",
-    titleLinkClasses: "transition hover:text-sky-300",
-    descriptionClasses: "text-sm text-slate-300",
-    ctaContainerClasses: "mt-auto flex flex-wrap gap-3 text-xs sm:text-sm",
-    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300",
-    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-sky-500 px-3 py-1 font-semibold text-sky-300 transition hover:bg-sky-500/10",
-    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-200 transition hover:border-sky-500 hover:text-sky-300"
+    articleClasses: "rounded-2xl border border-stone-300 bg-stone-50/80 p-5",
+    metaClasses: "text-xs uppercase tracking-[0.2em] text-stone-500",
+    titleClasses: "font-serif text-2xl text-stone-900",
+    titleLinkClasses: "text-link",
+    descriptionClasses: "text-sm leading-relaxed text-stone-700",
+    ctaContainerClasses: "mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-[0.16em]",
+    primaryCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-400 px-3 py-1 font-semibold text-stone-700 hover:border-stone-900 hover:text-stone-900",
+    websiteCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-400 px-3 py-1 font-semibold text-stone-700 hover:border-stone-900 hover:text-stone-900",
+    githubCtaClasses: "inline-flex items-center gap-2 rounded-full border border-stone-400 px-3 py-1 font-semibold text-stone-700 hover:border-stone-900 hover:text-stone-900"
   }
 } %}
 

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -1,22 +1,22 @@
 ---
 layout: base.njk
 ---
-<main class="px-6 py-16 sm:px-10">
-  <article class="mx-auto flex max-w-3xl flex-col gap-8">
+<main class="px-6 py-10 sm:px-10 sm:py-14">
+  <article class="paper-frame mx-auto flex max-w-3xl flex-col gap-8 px-6 py-8 sm:px-10 sm:py-10">
     {% if title or sectionLabel or description %}
-      <header class="flex flex-col gap-4 text-slate-100">
+      <header class="flex flex-col gap-4 text-stone-900">
         {% if sectionLabel %}
-          <p class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">{{ sectionLabel }}</p>
+          <p class="section-kicker">{{ sectionLabel }}</p>
         {% endif %}
         {% if title %}
-          <h1 class="text-3xl font-semibold text-slate-100 sm:text-4xl">{{ title }}</h1>
+          <h1 class="font-serif text-5xl leading-tight">{{ title }}</h1>
         {% endif %}
         {% if description %}
-          <p class="text-lg text-slate-300">{{ description }}</p>
+          <p class="text-lg text-stone-600">{{ description }}</p>
         {% endif %}
       </header>
     {% endif %}
-    <div class="prose prose-invert prose-lg max-w-none">
+    <div class="prose prose-lg max-w-none">
       {{ content | safe }}
     </div>
   </article>

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -1,20 +1,20 @@
 ---
 layout: base.njk
 ---
-<main class="px-3 py-8 sm:px-5 sm:py-10">
+<main class="px-4 py-8 sm:px-8 sm:py-12">
 {% from "components/blog-meta.njk" import renderPostHeader %}
-  <article class="blog-post mx-auto flex max-w-3xl flex-col gap-10 rounded-3xl border border-slate-800/60 bg-slate-900/40 px-3 py-8 sm:px-5 sm:py-6">
+  <article class="blog-post paper-frame mx-auto flex max-w-3xl flex-col gap-10 px-4 py-8 sm:px-8 sm:py-10">
     {{
       renderPostHeader(title, isoDate, displayDate, topicTagLinks, topicTags, {
         type: type,
         typeLabel: typeLabel,
         typeOptions: {
-          variantOverride: "border-slate-700/70 bg-slate-900/70 text-slate-200"
+          variantOverride: "border-stone-300 bg-stone-100 text-stone-700"
         }
       })
       | safe
     }}
-    <div class="prose prose-invert prose-lg max-w-none">
+    <div class="prose prose-lg max-w-none">
       {{ content | safe }}
     </div>
 
@@ -28,7 +28,7 @@ layout: base.njk
         data-reactions-enabled="1"
         data-emit-metadata="0"
         data-input-position="bottom"
-        data-theme="dark"
+        data-theme="light"
         data-lang="en"
         crossorigin="anonymous"
         async>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -6,16 +6,15 @@
 
 @layer base {
   :root {
-    color-scheme: dark;
+    color-scheme: light;
   }
 
   body {
-    @apply min-h-screen bg-slate-950 font-sans text-slate-100 antialiased selection:bg-sky-500/30 selection:text-slate-100;
+    @apply min-h-screen bg-stone-100 font-sans text-stone-800 antialiased selection:bg-amber-200 selection:text-stone-900;
     background-image:
-      radial-gradient(circle at 20% 20%, rgba(125, 90, 240, 0.15), rgba(14, 23, 42, 0.1) 45%),
-      radial-gradient(circle at 80% 10%, rgba(19, 194, 194, 0.25), rgba(6, 11, 19, 0.05) 50%),
-      radial-gradient(circle at 50% 90%, rgba(148, 240, 90, 0.14), rgba(15, 23, 42, 0.1) 55%),
-      linear-gradient(180deg, rgba(10, 10, 20, 0.95), rgba(5, 9, 18, 0.92));
+      radial-gradient(circle at 8% 10%, rgba(180, 160, 120, 0.15), transparent 38%),
+      radial-gradient(circle at 90% 20%, rgba(120, 145, 170, 0.14), transparent 35%),
+      linear-gradient(180deg, #f6f2ea 0%, #efe9dd 100%);
     background-attachment: fixed;
   }
 
@@ -24,92 +23,62 @@
   }
 
   code {
-    @apply rounded-md bg-slate-900/70 px-1 py-0.5 font-mono text-sky-300;
+    @apply rounded bg-stone-200 px-1 py-0.5 font-mono text-stone-800;
   }
 
   .prose code::before,
   .prose code::after {
     content: none;
   }
+
+  .prose {
+    @apply text-stone-700;
+  }
+
+  .prose a {
+    @apply text-stone-900 underline decoration-stone-400 underline-offset-2 hover:decoration-stone-700;
+  }
 }
 
 @layer components {
-  .glow-card {
-    @apply relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/40 p-6 shadow-glow transition-transform duration-300 ease-out;
+  .paper-frame {
+    @apply rounded-3xl border border-stone-300/90 bg-stone-50/95 shadow-[0_18px_55px_-28px_rgba(41,37,36,0.35)];
   }
 
-  .glow-card::before {
-    content: "";
-    position: absolute;
-    inset: -40% -20%;
-    background: conic-gradient(
-      from 90deg,
-      rgba(125, 90, 240, 0.35),
-      rgba(19, 194, 194, 0.25),
-      rgba(25, 255, 182, 0.2),
-      rgba(125, 90, 240, 0.35)
-    );
-    opacity: 0.35;
-    filter: blur(60px);
-    transform: rotate(15deg);
-    transition: opacity 0.3s ease;
-    pointer-events: none;
+  .section-kicker {
+    @apply text-xs font-semibold uppercase tracking-[0.3em] text-stone-500;
   }
 
-  .glow-card:hover {
-    transform: translateY(-6px) scale(1.01);
-  }
-
-  .glow-card:hover::before {
-    opacity: 0.6;
+  .text-link {
+    @apply text-stone-700 hover:text-stone-950;
   }
 
   .terminal-panel {
-    @apply relative overflow-hidden rounded-3xl border border-lime-400/40 bg-slate-950/80 font-mono text-lime-200 shadow-glow;
-    box-shadow:
-      inset 0 0 40px rgba(56, 189, 248, 0.1),
-      0 0 80px rgba(125, 90, 240, 0.25);
-  }
-
-  .terminal-panel::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(148, 240, 90, 0.03) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(148, 240, 90, 0.03) 1px, transparent 1px);
-    background-size: 0.75rem 0.75rem;
-    mix-blend-mode: screen;
-    opacity: 0.8;
-    pointer-events: none;
+    @apply overflow-hidden rounded-2xl border border-stone-300 bg-stone-950 text-stone-100 shadow-[0_20px_45px_-25px_rgba(12,10,9,0.65)];
   }
 
   .terminal-header {
-    @apply flex items-center gap-2 border-b border-lime-400/30 bg-slate-900/60 px-6 py-3;
+    @apply flex items-center gap-2 border-b border-stone-700 bg-stone-900 px-5 py-3;
   }
 
   .terminal-dot {
-    @apply inline-block h-3 w-3 rounded-full;
-    box-shadow: 0 0 10px rgba(148, 240, 90, 0.4);
+    @apply inline-block h-2.5 w-2.5 rounded-full;
   }
 
   .terminal-dot--close {
-    background-color: #ff5f57;
-    box-shadow: 0 0 8px rgba(255, 95, 87, 0.65);
+    background-color: #f87171;
   }
 
   .terminal-dot--minimize {
-    background-color: #febb2e;
-    box-shadow: 0 0 8px rgba(254, 187, 46, 0.65);
+    background-color: #fbbf24;
   }
 
   .terminal-dot--zoom {
-    background-color: #28c840;
-    box-shadow: 0 0 8px rgba(40, 200, 64, 0.65);
+    background-color: #34d399;
   }
 
   .terminal-body {
-    @apply flex flex-col gap-0 px-6 py-6 text-sm leading-relaxed text-lime-200/90;
+    @apply flex flex-col gap-0 px-5 py-5 font-mono text-sm leading-relaxed;
   }
 
   .terminal-output {
@@ -121,15 +90,15 @@
   }
 
   .terminal-line__prompt {
-    @apply select-none text-lime-200/80;
+    @apply select-none text-stone-400;
   }
 
   .terminal-line__command {
-    @apply text-fuchsia-300;
+    @apply text-amber-200;
   }
 
   .terminal-block {
-    @apply whitespace-pre-wrap break-words text-lime-100/90;
+    @apply whitespace-pre-wrap break-words text-stone-100;
     margin: 0;
   }
 
@@ -143,8 +112,8 @@
   }
 
   .terminal-input {
-    @apply flex-1 bg-transparent font-mono text-sm text-lime-100 placeholder:text-lime-100/40 focus:outline-none;
-    caret-color: rgba(186, 230, 253, 0.9);
+    @apply flex-1 bg-transparent font-mono text-sm text-stone-100 placeholder:text-stone-500 focus:outline-none;
+    caret-color: #fde68a;
   }
 
   .terminal-block--pending {
@@ -152,74 +121,6 @@
   }
 
   .terminal-block--error {
-    @apply text-red-300;
-  }
-
-  .terminal-links {
-    @apply mt-4 flex flex-col gap-1;
-  }
-
-  .terminal-link {
-    @apply text-sm font-medium text-lime-100 transition hover:text-sky-200;
-  }
-
-  .skew-panel {
-    clip-path: polygon(0% 6%, 100% 0%, 100% 94%, 0% 100%);
-  }
-
-  .grid-overlay {
-    position: absolute;
-    inset: -50% -50%;
-    background-image:
-      linear-gradient(rgba(125, 90, 240, 0.2) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(19, 194, 194, 0.2) 1px, transparent 1px);
-    background-size: 90px 90px;
-    opacity: 0.15;
-    animation: gridShift 16s linear infinite;
-    pointer-events: none;
-  }
-
-  .accent-stripe {
-    position: relative;
-    isolation: isolate;
-  }
-
-  .accent-stripe::before {
-    content: "";
-    position: absolute;
-    inset: -20px -40px;
-    background: linear-gradient(135deg, rgba(125, 90, 240, 0.6), rgba(19, 194, 194, 0.3));
-    filter: blur(60px);
-    opacity: 0.55;
-    transform: skewY(-6deg);
-    z-index: -1;
-  }
-}
-
-@layer utilities {
-  .perspective-1200 {
-    perspective: 1200px;
-  }
-
-  .backface-hidden {
-    backface-visibility: hidden;
-  }
-
-  .parallax {
-    position: relative;
-    transform-style: preserve-3d;
-  }
-
-  .parallax-layer {
-    position: absolute;
-    inset: 0;
-    will-change: transform;
-    pointer-events: none;
-  }
-
-  .dot-matrix {
-    background-image: radial-gradient(rgba(148, 240, 90, 0.35) 1px, transparent 1px);
-    background-size: 8px 8px;
-    opacity: 0.5;
+    @apply text-rose-300;
   }
 }


### PR DESCRIPTION
### Motivation
- Replace the current neon/cyberpunk visual treatment with a calmer, editorial-first design to improve readability, reduce visual noise, and provide a more timeless tone. 
- Introduce serif-forward typographic hierarchy and warm neutral backgrounds to better frame long-form content and project case studies. 

### Description
- Swap the global color/tone and typography by rewriting `src/styles/tailwind.css` to a light, warm paper palette and switching fonts to `Inter` + `Newsreader`, and simplify the shell in `src/layouts/base.njk`. 
- Rebuild the homepage hero and supporting sections (`src/layouts/components/home/*`) to use consistent `paper-frame` card framing, serif headings, and quieter CTAs while keeping the interactive orb and terminal functionality. 
- Update blog/work primitives (`src/layouts/components/blog-meta.njk`, `src/layouts/components/work-card.njk`, `src/layouts/components/post-list.njk`, `src/layouts/blog-list.njk`) to a unified editorial style (tag badges, metadata, list cards). 
- Adjust post/page templates (`src/layouts/post.njk`, `src/layouts/page.njk`) to the new visual system and set the discussion widget (`giscus`) to the light theme so comments visually match the redesign. 

### Testing
- Ran formatting with `npm run format` and lint/check with `npm run check`, both completed successfully. 
- Executed unit tests with `npm test` (Vitest) which passed. 
- Built the site with `npm run build` (Tailwind build + Eleventy) and the static site generation completed without errors. 
- Attempted to capture a screenshot with Playwright, but browser binaries could not be downloaded in this environment (Playwright download returned HTTP 403), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0565d7c9c832bb4492f4c6bcce3dd)